### PR TITLE
Feat/account lockout

### DIFF
--- a/src/migrations/1706100000000-AddAccountLockoutToUsers.ts
+++ b/src/migrations/1706100000000-AddAccountLockoutToUsers.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddAccountLockoutToUsers1706100000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'users',
+      new TableColumn({
+        name: 'failedLoginAttempts',
+        type: 'integer',
+        default: 0,
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'users',
+      new TableColumn({
+        name: 'lockedUntil',
+        type: 'timestamp',
+        nullable: true,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('users', 'lockedUntil');
+    await queryRunner.dropColumn('users', 'failedLoginAttempts');
+  }
+}

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -4,10 +4,13 @@ import {
   Get,
   Body,
   Query,
+  Param,
   HttpCode,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
+import { UsersService } from '../users/users.service';
 import { RegisterDto } from '../users/dto/register.dto';
 import { LoginDto } from '../users/dto/login.dto';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
@@ -16,6 +19,8 @@ import { ResetPasswordDto } from './dto/reset-password.dto';
 import { VerifyEmailQueryDto } from './dto/verify-email-query.dto';
 import { AuthThrottle } from '../throttler/throttler.decorator';
 import { Public } from './decorators/public.decorator';
+import { RolesGuard } from './roles.guard';
+import { Roles } from './decorators/roles.decorator';
 import {
   ApiBody,
   ApiCreatedResponse,
@@ -28,12 +33,17 @@ import {
   ApiTooManyRequestsResponse,
   ApiUnauthorizedResponse,
   ApiBadRequestResponse,
+  ApiParam,
+  ApiResponse,
 } from '@nestjs/swagger';
 
 @ApiTags('auth')
 @Controller('v1/auth')
 export class AuthController {
-  constructor(private authService: AuthService) { }
+  constructor(
+    private authService: AuthService,
+    private usersService: UsersService,
+  ) { }
 
   @AuthThrottle()
   @Post('register')
@@ -97,7 +107,7 @@ export class AuthController {
   @ApiOperation({
     summary: 'Login',
     description:
-      'Authenticates a verified user and returns JWT access token, refresh token, and user. Rate limited to 5 requests per 15 minutes.',
+      'Authenticates a verified user and returns JWT access token, refresh token, and user. Implements account lockout after 5 failed attempts (15 minutes). Rate limited to 5 requests per 15 minutes.',
   })
   @ApiBody({
     type: LoginDto,
@@ -125,6 +135,17 @@ export class AuthController {
       },
     },
   })
+  @ApiResponse({
+    status: 423,
+    description: 'Account locked due to too many failed login attempts.',
+    schema: {
+      example: {
+        statusCode: 423,
+        message: 'Account is locked. Please try again in 900 seconds.',
+        error: 'Locked',
+      },
+    },
+  })
   @ApiUnauthorizedResponse({
     description: 'Invalid credentials.',
     schema: {
@@ -136,7 +157,7 @@ export class AuthController {
     },
   })
   @ApiForbiddenResponse({
-    description: 'Email not verified.',
+    description: 'Email not verified or account deleted.',
     schema: {
       example: {
         statusCode: 403,
@@ -304,5 +325,59 @@ export class AuthController {
   })
   async resetPassword(@Body() dto: ResetPasswordDto) {
     return this.authService.resetPassword(dto);
+  }
+
+  @UseGuards(RolesGuard)
+  @Roles('ADMIN')
+  @Post('unlock/:userId')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Unlock account (Admin only)',
+    description:
+      'Manually unlocks a user account and resets failed login attempt counter. Requires ADMIN role.',
+  })
+  @ApiParam({
+    name: 'userId',
+    description: 'User ID to unlock',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @ApiOkResponse({
+    description: 'Account unlocked successfully.',
+    schema: {
+      example: {
+        id: 'abc123',
+        email: 'user@example.com',
+        roles: ['USER'],
+        isEmailVerified: true,
+        isActive: true,
+        failedLoginAttempts: 0,
+        lockedUntil: null,
+        createdAt: '2026-01-26T10:00:00.000Z',
+        updatedAt: '2026-01-26T10:00:00.000Z',
+      },
+    },
+  })
+  @ApiForbiddenResponse({
+    description: 'User does not have ADMIN role.',
+    schema: {
+      example: {
+        statusCode: 403,
+        message: 'Forbidden resource',
+        error: 'Forbidden',
+      },
+    },
+  })
+  @ApiBadRequestResponse({
+    description: 'User not found.',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: 'User with ID abc123 not found',
+        error: 'Not Found',
+      },
+    },
+  })
+  async unlockAccount(@Param('userId') userId: string) {
+    return this.usersService.unlockAccount(userId);
   }
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -3,7 +3,10 @@ import {
   UnauthorizedException,
   ForbiddenException,
   BadRequestException,
+  HttpException,
+  HttpStatus,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -24,11 +27,14 @@ import { MailService } from './mail/mail.service';
 @Injectable()
 export class AuthService {
   private readonly logger: Logger;
+  private readonly maxFailedAttempts: number;
+  private readonly lockDurationMinutes: number;
 
   constructor(
     private usersService: UsersService,
     private jwtService: JwtService,
     private mailService: MailService,
+    private configService: ConfigService,
     @InjectRepository(RefreshToken)
     private refreshTokenRepository: Repository<RefreshToken>,
     @InjectRepository(PasswordResetToken)
@@ -36,6 +42,8 @@ export class AuthService {
     appLogger: AppLogger,
   ) {
     this.logger = appLogger.child({ module: AuthService.name });
+    this.maxFailedAttempts = this.configService.get<number>('LOGIN_MAX_ATTEMPTS', 5);
+    this.lockDurationMinutes = this.configService.get<number>('LOGIN_LOCK_DURATION_MINUTES', 15);
   }
 
   async register(
@@ -83,6 +91,26 @@ export class AuthService {
       throw new UnauthorizedException('Invalid credentials');
     }
 
+    // Check if account is locked
+    if (this.usersService.isAccountLocked(user)) {
+      const secondsUntilUnlock = this.usersService.getSecondsUntilUnlock(user);
+      const error: any = new HttpException(
+        {
+          statusCode: 423,
+          message: `Account is locked. Please try again in ${secondsUntilUnlock} seconds.`,
+          error: 'Locked',
+        },
+        HttpStatus.LOCKED,
+      );
+      error.getResponse = () => ({
+        statusCode: 423,
+        message: `Account is locked. Please try again in ${secondsUntilUnlock} seconds.`,
+        error: 'Locked',
+      });
+      error.getStatus = () => 423;
+      throw error;
+    }
+
     if (user.deletedAt) {
       throw new ForbiddenException(
         'This account has been deleted. Please contact support to restore your account.',
@@ -94,6 +122,12 @@ export class AuthService {
       user.password,
     );
     if (!isPasswordValid) {
+      // Increment failed login attempts
+      await this.usersService.incrementFailedLoginAttempts(
+        user.id,
+        this.maxFailedAttempts,
+        this.lockDurationMinutes,
+      );
       throw new UnauthorizedException('Invalid credentials');
     }
 
@@ -102,6 +136,9 @@ export class AuthService {
         'Email address not verified. Please check your inbox and verify your email before logging in.',
       );
     }
+
+    // Reset failed login attempts on successful login
+    await this.usersService.resetFailedLoginAttempts(user.id);
 
     const payload = { sub: user.id, email: user.email, roles: user.roles };
     const [access_token, refresh_token] = await Promise.all([

--- a/src/modules/users/user.entity.ts
+++ b/src/modules/users/user.entity.ts
@@ -1,14 +1,45 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import { UserRole } from '../../common/constants/roles';
 
+@Entity('users')
 export class User {
+  @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @Column({ unique: true })
   email: string;
+
+  @Column()
   password: string;
+
+  @Column('text', { array: true, default: [UserRole.USER] })
   roles: UserRole[] = [UserRole.USER];
+
+  @Column({ default: false })
   isEmailVerified: boolean = false;
+
+  @Column({ default: true })
   isActive: boolean = true;
+
+  @Column({ nullable: true })
   deletedAt: Date | null = null;
+
+  @Column({ default: 0 })
+  failedLoginAttempts: number = 0;
+
+  @Column({ nullable: true })
+  lockedUntil: Date | null = null;
+
+  @CreateDateColumn()
   createdAt: Date;
+
+  @UpdateDateColumn()
   updatedAt: Date;
 
   constructor(partial?: Partial<User>) {
@@ -24,6 +55,12 @@ export class User {
     }
     if (this.deletedAt === undefined) {
       this.deletedAt = null;
+    }
+    if (this.failedLoginAttempts === undefined) {
+      this.failedLoginAttempts = 0;
+    }
+    if (this.lockedUntil === undefined) {
+      this.lockedUntil = null;
     }
   }
 }

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
+import { User } from './user.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([User])],
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -1,4 +1,6 @@
 import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { User } from './user.entity';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -9,30 +11,31 @@ import { Logger } from 'pino';
 
 @Injectable()
 export class UsersService {
-  private users: User[] = [];
   private readonly logger: Logger;
 
-  constructor(appLogger: AppLogger) {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    appLogger: AppLogger,
+  ) {
     this.logger = appLogger.child({ module: UsersService.name });
   }
 
   async create(createUserDto: CreateUserDto): Promise<Omit<User, 'password'>> {
     const hashedPassword = await bcrypt.hash(createUserDto.password, 10);
 
-    const user: User = {
-      id: Math.random().toString(36).substring(7),
+    const user = this.userRepository.create({
       email: createUserDto.email,
       password: hashedPassword,
       roles: [UserRole.USER],
       isEmailVerified: false,
       isActive: true,
-      deletedAt: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
+      failedLoginAttempts: 0,
+      lockedUntil: null,
+    });
 
-    this.users.push(user);
-    const { password, ...result } = user;
+    const savedUser = await this.userRepository.save(user);
+    const { password, ...result } = savedUser;
     this.logger.info(
       { userId: result.id, email: result.email },
       'User created',
@@ -46,36 +49,39 @@ export class UsersService {
     sortBy?: string;
     search?: string;
   }): Promise<import('../../common/interfaces').PaginatedResult<Omit<User, 'password'>>> {
-    // Filter out soft-deleted users
-    let filtered = this.users.filter(u => !u.deletedAt);
+    const query = this.userRepository.createQueryBuilder('user')
+      .where('user.deletedAt IS NULL');
 
     // Filtering by email (partial match)
     if (params?.search) {
-      const searchLower = params.search.toLowerCase();
-      filtered = filtered.filter((u) => u.email.toLowerCase().includes(searchLower));
-    }
-    // Sorting
-    if (params?.sortBy && ['email', 'createdAt', 'updatedAt'].includes(params.sortBy)) {
-      const sortKey = params.sortBy as 'email' | 'createdAt' | 'updatedAt';
-      filtered = filtered.slice().sort((a, b) => {
-        if (sortKey === 'email') {
-          return a.email.localeCompare(b.email);
-        }
-        return new Date(a[sortKey]).getTime() - new Date(b[sortKey]).getTime();
+      query.andWhere('user.email ILIKE :search', {
+        search: `%${params.search}%`,
       });
     }
+
+    // Sorting
+    if (params?.sortBy && ['email', 'createdAt', 'updatedAt'].includes(params.sortBy)) {
+      query.orderBy(`user.${params.sortBy}`, 'ASC');
+    }
+
     // Pagination
     const page = Math.max(1, params?.page ?? 1);
     const limit = Math.min(Math.max(1, params?.limit ?? 20), 100);
-    const total = filtered.length;
-    const start = (page - 1) * limit;
-    const end = start + limit;
-    const data = filtered.slice(start, end).map(({ password, ...rest }) => rest);
+    const skip = (page - 1) * limit;
+
+    const [users, total] = await query
+      .skip(skip)
+      .take(limit)
+      .getManyAndCount();
+
+    const data = users.map(({ password, ...rest }) => rest);
     return { data, total, page, limit };
   }
 
   async findOne(id: string): Promise<Omit<User, 'password'>> {
-    const user = this.users.find((user) => user.id === id && !user.deletedAt);
+    const user = await this.userRepository.findOne({
+      where: { id, deletedAt: null },
+    });
     if (!user) {
       throw new NotFoundException(`User with ID ${id} not found`);
     }
@@ -84,15 +90,19 @@ export class UsersService {
   }
 
   async findByEmail(email: string): Promise<User | undefined> {
-    return this.users.find((user) => user.email === email && !user.deletedAt);
+    return await this.userRepository.findOne({
+      where: { email, deletedAt: null },
+    });
   }
 
   async update(
     id: string,
     updateUserDto: UpdateUserDto,
   ): Promise<Omit<User, 'password'>> {
-    const userIndex = this.users.findIndex((user) => user.id === id && !user.deletedAt);
-    if (userIndex === -1) {
+    const user = await this.userRepository.findOne({
+      where: { id, deletedAt: null },
+    });
+    if (!user) {
       throw new NotFoundException(`User with ID ${id} not found`);
     }
 
@@ -101,15 +111,12 @@ export class UsersService {
       updates.password = await bcrypt.hash(updateUserDto.password, 10);
     }
 
-    const updatedUser = {
-      ...this.users[userIndex],
-      ...updates,
-      updatedAt: new Date(),
-    };
+    Object.assign(user, updates);
+    user.updatedAt = new Date();
 
-    this.users[userIndex] = updatedUser;
-
+    const updatedUser = await this.userRepository.save(user);
     const { password, ...result } = updatedUser;
+
     const updatedFields = Object.keys(updateUserDto).filter(
       (key) => key !== 'password',
     );
@@ -120,55 +127,176 @@ export class UsersService {
   }
 
   async softDelete(id: string): Promise<void> {
-    const userIndex = this.users.findIndex((user) => user.id === id && !user.deletedAt);
-    if (userIndex === -1) {
+    const user = await this.userRepository.findOne({
+      where: { id, deletedAt: null },
+    });
+    if (!user) {
       throw new NotFoundException(`User with ID ${id} not found`);
     }
-    this.users[userIndex].deletedAt = new Date();
-    this.users[userIndex].isActive = false;
-    this.users[userIndex].updatedAt = new Date();
+    user.deletedAt = new Date();
+    user.isActive = false;
+    user.updatedAt = new Date();
+    await this.userRepository.save(user);
     this.logger.info({ userId: id }, 'User soft deleted');
   }
 
   async remove(id: string): Promise<void> {
-    const userIndex = this.users.findIndex((user) => user.id === id);
-    if (userIndex === -1) {
+    const user = await this.userRepository.findOne({ where: { id } });
+    if (!user) {
       throw new NotFoundException(`User with ID ${id} not found`);
     }
-    this.users.splice(userIndex, 1);
+    await this.userRepository.remove(user);
     this.logger.info({ userId: id }, 'User removed');
   }
 
   async restore(id: string): Promise<Omit<User, 'password'>> {
-    const userIndex = this.users.findIndex((user) => user.id === id && user.deletedAt);
-    if (userIndex === -1) {
+    const user = await this.userRepository.findOne({
+      where: { id, deletedAt: null },
+    });
+    if (!user) {
       throw new NotFoundException(`Deleted user with ID ${id} not found`);
     }
-    this.users[userIndex].deletedAt = null;
-    this.users[userIndex].isActive = true;
-    this.users[userIndex].updatedAt = new Date();
-    const { password, ...result } = this.users[userIndex];
+    user.deletedAt = null;
+    user.isActive = true;
+    user.updatedAt = new Date();
+    const savedUser = await this.userRepository.save(user);
+    const { password, ...result } = savedUser;
     this.logger.info({ userId: id }, 'User restored');
     return result;
   }
 
   async verifyEmail(id: string): Promise<void> {
-    const userIndex = this.users.findIndex((user) => user.id === id && !user.deletedAt);
-    if (userIndex === -1) {
+    const user = await this.userRepository.findOne({
+      where: { id, deletedAt: null },
+    });
+    if (!user) {
       throw new NotFoundException(`User with ID ${id} not found`);
     }
-    this.users[userIndex].isEmailVerified = true;
-    this.users[userIndex].updatedAt = new Date();
+    user.isEmailVerified = true;
+    user.updatedAt = new Date();
+    await this.userRepository.save(user);
     this.logger.info({ userId: id }, 'User email verified');
   }
 
   async updatePassword(id: string, hashedPassword: string): Promise<void> {
-    const userIndex = this.users.findIndex((user) => user.id === id);
-    if (userIndex === -1) {
+    const user = await this.userRepository.findOne({ where: { id } });
+    if (!user) {
       throw new NotFoundException(`User with ID ${id} not found`);
     }
-    this.users[userIndex].password = hashedPassword;
-    this.users[userIndex].updatedAt = new Date();
+    user.password = hashedPassword;
+    user.updatedAt = new Date();
+    await this.userRepository.save(user);
     this.logger.info({ userId: id }, 'User password updated');
+  }
+
+  /**
+   * Increment failed login attempts and lock account if threshold reached
+   */
+  async incrementFailedLoginAttempts(
+    userId: string,
+    maxAttempts: number = 5,
+    lockDurationMinutes: number = 15,
+  ): Promise<number> {
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException(`User with ID ${userId} not found`);
+    }
+
+    user.failedLoginAttempts = (user.failedLoginAttempts || 0) + 1;
+    user.updatedAt = new Date();
+
+    // Lock account if max attempts reached
+    if (user.failedLoginAttempts >= maxAttempts) {
+      user.lockedUntil = new Date(Date.now() + lockDurationMinutes * 60 * 1000);
+      this.logger.warn(
+        { userId, failedAttempts: user.failedLoginAttempts },
+        'Account locked due to failed login attempts',
+      );
+    } else {
+      this.logger.debug(
+        { userId, failedAttempts: user.failedLoginAttempts },
+        'Failed login attempt recorded',
+      );
+    }
+
+    await this.userRepository.save(user);
+    return user.failedLoginAttempts;
+  }
+
+  /**
+   * Reset failed login attempts on successful login
+   */
+  async resetFailedLoginAttempts(userId: string): Promise<void> {
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException(`User with ID ${userId} not found`);
+    }
+
+    if (user.failedLoginAttempts > 0 || user.lockedUntil) {
+      user.failedLoginAttempts = 0;
+      user.lockedUntil = null;
+      user.updatedAt = new Date();
+      await this.userRepository.save(user);
+      this.logger.info(
+        { userId },
+        'Failed login attempts reset on successful login',
+      );
+    }
+  }
+
+  /**
+   * Check if account is locked
+   */
+  isAccountLocked(user: User): boolean {
+    if (!user.lockedUntil) {
+      return false;
+    }
+
+    const now = new Date();
+    const isLocked = new Date(user.lockedUntil) > now;
+
+    // Clear lock if expired
+    if (!isLocked && user.lockedUntil) {
+      user.lockedUntil = null;
+      user.failedLoginAttempts = 0;
+      this.userRepository.save(user);
+    }
+
+    return isLocked;
+  }
+
+  /**
+   * Get seconds remaining until account is unlocked
+   */
+  getSecondsUntilUnlock(user: User): number {
+    if (!user.lockedUntil) {
+      return 0;
+    }
+
+    const now = new Date();
+    const unlockTime = new Date(user.lockedUntil);
+    const secondsRemaining = Math.ceil((unlockTime.getTime() - now.getTime()) / 1000);
+
+    return Math.max(0, secondsRemaining);
+  }
+
+  /**
+   * Manually unlock an account (admin only)
+   */
+  async unlockAccount(userId: string): Promise<Omit<User, 'password'>> {
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException(`User with ID ${userId} not found`);
+    }
+
+    user.failedLoginAttempts = 0;
+    user.lockedUntil = null;
+    user.updatedAt = new Date();
+
+    const savedUser = await this.userRepository.save(user);
+    this.logger.info({ userId }, 'Account unlocked by admin');
+
+    const { password, ...result } = savedUser;
+    return result;
   }
 }


### PR DESCRIPTION
## feat: Add brute-force protection with account lockout
close #43
### Description
Implemented account lockout mechanism to protect against brute-force attacks on the login endpoint.

### Changes
- **User Entity**: Added `failedLoginAttempts` and `lockedUntil` columns
- **UsersService**: 
  - Migrated to TypeORM repository
  - Added `incrementFailedLoginAttempts()` method
  - Added `resetFailedLoginAttempts()` method
  - Added `isAccountLocked()` and `getSecondsUntilUnlock()` helpers
  - Added `unlockAccount()` admin method
  
- **AuthService**: 
  - Check account lock status before password validation
  - Increment failures on invalid password
  - Reset counter on successful login
  - Configurable via env variables (`LOGIN_MAX_ATTEMPTS`, `LOGIN_LOCK_DURATION_MINUTES`)

- **AuthController**: 
  - New endpoint: `POST /v1/auth/unlock/:userId` (ADMIN only)
  - Updated login endpoint docs with lockout info

- **Database**: Migration to add lockout columns to users table

### Features
✅ Account locked after 5 consecutive failed attempts
✅ Returns 423 (Locked) status with remaining time
✅ Failed counter resets on successful login
✅ Lock duration configurable via environment variables (default 15 minutes)
✅ Admin can manually unlock accounts
✅ Clean error handling and logging

### Configuration
```env
LOGIN_MAX_ATTEMPTS=5
LOGIN_LOCK_DURATION_MINUTES=15