### PR TITLE
feat: add Swagger bearer token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,26 +57,42 @@ Body:
 
 ## 🔐 Authentication
 
-The API includes a JWT-based authentication system with the following endpoints:
+The API uses JWT bearer tokens. Swagger UI is available at `http://localhost:3000/api/docs` with built-in token authorization.
+
+### How to authenticate in Swagger
+
+1. Call `POST /v1/auth/login` with your credentials to receive an `access_token`
+2. Click the **Authorize** button (🔓) in the top-right of Swagger UI
+3. Paste the token in the `bearer` field and click **Authorize**
+4. All protected endpoints will now include the `Authorization: Bearer <token>` header automatically
+5. The token persists across page refreshes (`persistAuthorization: true`)
 
 ### Register a new user
 ```bash
-curl -X POST http://localhost:3000/auth/register \
+curl -X POST http://localhost:3000/v1/auth/register \
   -H "Content-Type: application/json" \
-  -d '{"email":"user@example.com","password":"password123"}'
+  -d '{"email":"user@example.com","password":"P@ssw0rd!"}'
 ```
 
-### Login user
+### Login and obtain token
 ```bash
-curl -X POST http://localhost:3000/auth/login \
+curl -X POST http://localhost:3000/v1/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"email":"user@example.com","password":"password123"}'
+  -d '{"email":"user@example.com","password":"P@ssw0rd!"}'
+# Response includes: access_token, refresh_token, user
 ```
 
 ### Access protected route
 ```bash
-curl -X GET http://localhost:3000/profile \
-  -H "Authorization: Bearer YOUR_JWT_TOKEN"
+curl -X GET http://localhost:3000/v1/users/me \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+### Refresh access token
+```bash
+curl -X POST http://localhost:3000/v1/auth/refresh \
+  -H "Content-Type: application/json" \
+  -d '{"refresh_token":"YOUR_REFRESH_TOKEN"}'
 ```
 
 ## 📁 Project Structure

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -51,8 +51,7 @@ export class AuthController {
   constructor(
     private authService: AuthService,
     private usersService: UsersService,
-  ) { }
-  constructor(private authService: AuthService) {}
+  ) {}
 
   @AuthThrottle()
   @Post('register')
@@ -446,10 +445,11 @@ export class AuthController {
     return this.authService.resetPassword(dto);
   }
 
-  @UseGuards(RolesGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('ADMIN')
   @Post('unlock/:userId')
   @HttpCode(HttpStatus.OK)
+  @ApiBearerAuth('bearer')
   @ApiOperation({
     summary: 'Unlock account (Admin only)',
     description:


### PR DESCRIPTION
## Summary

- Fixed duplicate constructor bug in `AuthController` that caused a TypeScript compile error
- Added `JwtAuthGuard` and `@ApiBearerAuth('bearer')` decorator to the `POST /v1/auth/unlock/:userId` endpoint which was missing both
- Documented the full Swagger authentication flow in README

## Changes

- `src/modules/auth/auth.controller.ts` — remove duplicate constructor, add bearer auth to unlock endpoint
- `README.md` — add step-by-step Swagger auth flow documentation

## Test plan

- [ ] Open `http://localhost:3000/api/docs` — Authorize button (🔓) visible in top-right
- [ ] Login via `POST /v1/auth/login`, paste `access_token` into Authorize dialog
- [ ] All protected endpoints show lock icon and include `Authorization: Bearer` header
- [ ] Token persists after page refresh
- [ ] `POST /v1/auth/unlock/:userId` shows lock icon in Swagger


🤖 Generated with [Claude Code](https://claude.com/claude-code)