### PR TITLE
feat: add user profile update endpoint (PATCH /users/me)

### DIFF
--- a/src/migrations/1706300000000-AddNameToUsers.ts
+++ b/src/migrations/1706300000000-AddNameToUsers.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddNameToUsers1706300000000 implements MigrationInterface {
+  name = 'AddNameToUsers1706300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "name" character varying`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN IF EXISTS "name"`);
+  }
+}

--- a/src/modules/users/dto/update-profile.dto.ts
+++ b/src/modules/users/dto/update-profile.dto.ts
@@ -1,0 +1,24 @@
+import { IsEmail, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateProfileDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  @ApiPropertyOptional({
+    description: 'Display name for the user.',
+    example: 'Jane Doe',
+    maxLength: 100,
+  })
+  name?: string;
+
+  @IsOptional()
+  @IsEmail({}, { message: 'Please provide a valid email address' })
+  @MaxLength(255)
+  @ApiPropertyOptional({
+    description: 'New email address. Triggers re-verification and resets isEmailVerified to false.',
+    example: 'jane.new@example.com',
+    maxLength: 255,
+  })
+  email?: string;
+}

--- a/src/modules/users/user.entity.ts
+++ b/src/modules/users/user.entity.ts
@@ -15,6 +15,9 @@ export class User {
   @Column({ unique: true })
   email: string;
 
+  @Column({ nullable: true })
+  name: string | null = null;
+
   @Column()
   password: string;
 

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -15,6 +15,7 @@ import { PaginatedResult } from '../../common/interfaces';
 import { Query } from '@nestjs/common';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { UpdateProfileDto } from './dto/update-profile.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
@@ -22,6 +23,7 @@ import { UserRole } from '../../common/constants/roles';
 import {
   ApiBearerAuth,
   ApiBody,
+  ApiConflictResponse,
   ApiCreatedResponse,
   ApiForbiddenResponse,
   ApiNoContentResponse,
@@ -143,6 +145,42 @@ export class UsersController {
   })
   findOne(@Param('id') id: string) {
     return this.usersService.findOne(id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch('me')
+  @ApiBearerAuth('bearer')
+  @ApiOperation({
+    summary: 'Update current user profile',
+    description: 'Updates the authenticated user\'s name and/or email. Email change triggers re-verification and resets isEmailVerified to false.',
+  })
+  @ApiBody({ type: UpdateProfileDto })
+  @ApiOkResponse({
+    description: 'Profile updated.',
+    schema: {
+      example: {
+        user: {
+          id: 'abc123',
+          email: 'jane.new@example.com',
+          name: 'Jane Doe',
+          isEmailVerified: false,
+          createdAt: '2026-01-26T10:00:00.000Z',
+          updatedAt: '2026-01-26T12:00:00.000Z',
+        },
+        emailChanged: true,
+      },
+    },
+  })
+  @ApiConflictResponse({
+    description: 'Email address already in use.',
+    schema: { example: { statusCode: 409, message: 'Email address is already in use' } },
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Missing or invalid access token.',
+    schema: { example: { statusCode: 401, message: 'Unauthorized' } },
+  })
+  async updateMe(@Request() req: any, @Body() dto: UpdateProfileDto) {
+    return this.usersService.updateMe(req.user.id, dto);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -1,9 +1,10 @@
-import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from './user.entity';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { UpdateProfileDto } from './dto/update-profile.dto';
 import { UserRole } from '../../common/constants/roles';
 import * as bcrypt from 'bcrypt';
 import { AppLogger } from '../logger/logger.service';
@@ -94,6 +95,41 @@ export class UsersService {
     return await this.userRepository.findOne({
       where: { email, deletedAt: null },
     });
+  }
+
+  async updateMe(
+    id: string,
+    dto: UpdateProfileDto,
+  ): Promise<{ user: Omit<User, 'password' | 'twoFactorSecret'>; emailChanged: boolean }> {
+    const user = await this.userRepository.findOne({ where: { id, deletedAt: null } });
+    if (!user) {
+      throw new NotFoundException(`User with ID ${id} not found`);
+    }
+
+    let emailChanged = false;
+
+    if (dto.email && dto.email !== user.email) {
+      const existing = await this.userRepository.findOne({
+        where: { email: dto.email, deletedAt: null },
+      });
+      if (existing) {
+        throw new ConflictException('Email address is already in use');
+      }
+      user.email = dto.email;
+      user.isEmailVerified = false;
+      emailChanged = true;
+    }
+
+    if (dto.name !== undefined) {
+      user.name = dto.name;
+    }
+
+    user.updatedAt = new Date();
+    const saved = await this.userRepository.save(user);
+    const { password, twoFactorSecret, ...result } = saved;
+
+    this.logger.info({ userId: id, emailChanged }, 'User profile updated');
+    return { user: result, emailChanged };
   }
 
   async findByIdWithSecrets(id: string): Promise<User> {


### PR DESCRIPTION
## Summary

- Add `PATCH /v1/users/me` endpoint for authenticated users to update their profile
- New `UpdateProfileDto` with optional `name` and `email` fields (no password via this endpoint)
- Email change: resets `isEmailVerified = false` so re-verification is required
- Duplicate email check: returns **409 Conflict** if new email is taken
- Add `name` column (nullable) to `User` entity + migration
- Endpoint registered before `PATCH :id` to prevent route shadowing

## Changes

- `src/modules/users/user.entity.ts` — add nullable `name` column
- `src/modules/users/dto/update-profile.dto.ts` — new DTO
- `src/modules/users/users.service.ts` — `updateMe()` method
- `src/modules/users/users.controller.ts` — `PATCH /me` endpoint
- `src/migrations/1706300000000-AddNameToUsers.ts` — migration

## Test plan

- [ ] `PATCH /v1/users/me` with `{ name: "Jane" }` → updates name, returns updated user
- [ ] `PATCH /v1/users/me` with new email → `isEmailVerified` becomes false
- [ ] `PATCH /v1/users/me` with email already used → 409 Conflict
- [ ] No token → 401
- [ ] Response never includes `password` or `twoFactorSecret`



🤖 Generated with [Claude Code](https://claude.com/claude-code)