### PR TITLE
feat: add structured logging with correlation IDs

### DIFF
--- a/src/modules/logger/correlation.context.ts
+++ b/src/modules/logger/correlation.context.ts
@@ -1,0 +1,11 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface CorrelationStore {
+  correlationId: string;
+}
+
+export const correlationStore = new AsyncLocalStorage<CorrelationStore>();
+
+export function getCorrelationId(): string | undefined {
+  return correlationStore.getStore()?.correlationId;
+}

--- a/src/modules/logger/http-logger.middleware.ts
+++ b/src/modules/logger/http-logger.middleware.ts
@@ -11,6 +11,7 @@ import {
   sanitizeHeaders,
 } from './logging.utils';
 import { Logger } from 'pino';
+import { correlationStore } from './correlation.context';
 
 const DEFAULT_BODY_MAX_LENGTH = 2048;
 
@@ -39,6 +40,16 @@ export class HttpLoggerMiddleware implements NestMiddleware {
     req.requestId = requestId;
     res.setHeader('x-request-id', requestId);
 
+    const incomingCorrelationId = req.headers['x-correlation-id'];
+    const correlationId =
+      (Array.isArray(incomingCorrelationId)
+        ? incomingCorrelationId[0]
+        : incomingCorrelationId) ?? randomUUID();
+    req.correlationId = correlationId;
+    res.setHeader('x-correlation-id', correlationId);
+
+    correlationStore.run({ correlationId }, () => {
+
     const startTime = process.hrtime.bigint();
     let responseBody: unknown;
 
@@ -65,6 +76,7 @@ export class HttpLoggerMiddleware implements NestMiddleware {
 
       const meta: Record<string, unknown> = {
         requestId,
+        correlationId,
         method: req.method,
         path,
         statusCode,
@@ -124,7 +136,8 @@ export class HttpLoggerMiddleware implements NestMiddleware {
       }
     });
 
-    next();
+      next();
+    });
   }
 }
 

--- a/src/modules/logger/logger.service.ts
+++ b/src/modules/logger/logger.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { mkdirSync } from 'node:fs';
 import pino, { Logger } from 'pino';
 import { buildLoggerConfig, buildTransportTargets } from './logger.config';
+import { getCorrelationId } from './correlation.context';
 
 @Injectable()
 export class AppLogger implements LoggerService {
@@ -28,6 +29,10 @@ export class AppLogger implements LoggerService {
           level(label) {
             return { level: label };
           },
+        },
+        mixin() {
+          const correlationId = getCorrelationId();
+          return correlationId ? { correlationId } : {};
         },
       },
       transport,

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -3,6 +3,7 @@ import 'express-serve-static-core';
 declare module 'express-serve-static-core' {
   interface Request {
     requestId?: string;
+    correlationId?: string;
     user?: {
       id?: string | number;
       userId?: string | number;


### PR DESCRIPTION
## Summary

- Every log line emitted during a request now includes the same `correlationId`
- Upstream services can pass `X-Correlation-Id` header — it is propagated and returned
- If no incoming ID, a new UUID is generated per request
- Uses Node.js `AsyncLocalStorage` to carry the ID through async call chains without thread-local hacks
- Pino `mixin` injects `correlationId` automatically into all log entries

## Changes

- `src/modules/logger/correlation.context.ts` — `AsyncLocalStorage` store + `getCorrelationId()`
- `src/modules/logger/http-logger.middleware.ts` — extract/generate correlation ID, wrap `next()` in `correlationStore.run()`; add `correlationId` to log meta
- `src/modules/logger/logger.service.ts` — add pino `mixin` to include `correlationId` in every entry
- `src/types/express.d.ts` — add `correlationId` to `Request` type

## Test plan

- [ ] Every log line for a request includes the same `correlationId`
- [ ] `X-Correlation-Id` response header matches the log `correlationId`
- [ ] Passing `X-Correlation-Id: abc123` in request → same value propagated through
- [ ] Log output is valid JSON parseable by log aggregators
- [ ] No `correlationId` in logs for code running outside a request context


🤖 Generated with [Claude Code](https://claude.com/claude-code)