### PR TITLE
feat: add Docker Compose setup for local development with hot reload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,21 @@
-FROM node:18-alpine
+FROM node:18-alpine AS builder
 
 WORKDIR /app
 
 COPY package*.json ./
+RUN npm ci
 
+COPY . .
+RUN npm run build
+
+FROM node:18-alpine AS production
+
+WORKDIR /app
+
+COPY package*.json ./
 RUN npm ci --only=production
 
-COPY dist ./dist
+COPY --from=builder /app/dist ./dist
 
 EXPOSE 3000
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,12 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "run", "start:dev"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: dev test migrate logs stop clean
+
+dev:
+	docker compose up --build
+
+test:
+	docker compose -f docker-compose.test.yml run --rm api-test
+
+migrate:
+	docker compose exec api npm run typeorm:migration:run
+
+logs:
+	docker compose logs -f api
+
+stop:
+	docker compose down
+
+clean:
+	docker compose down -v

--- a/README.md
+++ b/README.md
@@ -15,24 +15,42 @@ Backend API built with **NestJS**.
 
 ---
 
-## ⚙️ Setup Instructions
+## ⚙️ Quick Start (Docker — recommended)
+
+Prerequisites: Docker + Docker Compose.
+
+```bash
+cp .env.example .env
+docker compose up
+```
+
+The API will be available at `http://localhost:3000`. Hot-reload is enabled — changes to `src/` are picked up immediately.
+
+```bash
+# Run E2E tests against an isolated throwaway database
+make test
+# or
+docker compose -f docker-compose.test.yml run --rm api-test
+```
+
+## ⚙️ Setup (local, without Docker)
 
 1. Install dependencies
 ```bash
 npm install
 ```
 
-## Create environment file
+2. Create environment file
 ```bash
 cp .env.example .env
 ```
 
-## Run the application
+3. Run the application
 ```bash
 npm run start:dev
 ```
- ## The application will be available at:
-http://localhost:3000   
+
+Application available at `http://localhost:3000`.
 
 
 ```md

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,34 @@
+services:
+  api-test:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    environment:
+      NODE_ENV: test
+      DATABASE_HOST: db-test
+      DATABASE_PORT: 5432
+      DATABASE_USERNAME: facilpay_test
+      DATABASE_PASSWORD: facilpay_test
+      DATABASE_NAME: facilpay_test
+      DATABASE_SYNCHRONIZE: "true"
+      JWT_SECRET: test-jwt-secret
+      TWO_FACTOR_ENCRYPTION_KEY: test-2fa-secret
+      LOG_LEVEL: error
+    depends_on:
+      db-test:
+        condition: service_healthy
+    command: npm run test:e2e
+
+  db-test:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: facilpay_test
+      POSTGRES_PASSWORD: facilpay_test
+      POSTGRES_DB: facilpay_test
+    tmpfs:
+      - /var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U facilpay_test"]
+      interval: 5s
+      timeout: 5s
+      retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./src:/app/src
+      - ./package.json:/app/package.json
+    environment:
+      NODE_ENV: development
+      PORT: 3000
+      DATABASE_HOST: db
+      DATABASE_PORT: 5432
+      DATABASE_USERNAME: facilpay
+      DATABASE_PASSWORD: facilpay
+      DATABASE_NAME: facilpay
+      DATABASE_SYNCHRONIZE: "true"
+      JWT_SECRET: dev-jwt-secret-change-in-production
+      TWO_FACTOR_ENCRYPTION_KEY: dev-2fa-secret-change-in-production
+      LOG_LEVEL: debug
+      LOG_PRETTY: "true"
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: facilpay
+      POSTGRES_PASSWORD: facilpay
+      POSTGRES_DB: facilpay
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U facilpay"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary

New contributors can now onboard with a single command on a clean machine with only Docker installed.

- `docker compose up` — starts the API with hot reload (ts-node-dev) + PostgreSQL with healthcheck
- `docker compose -f docker-compose.test.yml run --rm api-test` — E2E tests against an isolated throwaway database (tmpfs, no persistent volume)
- `make test` — shortcut for the above
- Multi-stage production `Dockerfile` (builder + slim production image)
- `Dockerfile.dev` — dev image with all deps and `npm run start:dev`
- `Makefile` — shortcuts: `dev`, `test`, `migrate`, `logs`, `stop`, `clean`

## Changes

- `docker-compose.yml` — dev stack
- `docker-compose.test.yml` — E2E test stack
- `Dockerfile` — multi-stage production build
- `Dockerfile.dev` — development image
- `Makefile` — common commands
- `README.md` — Docker quick-start documentation

## Test plan

- [ ] `docker compose up` starts API on port 3000 with hot reload
- [ ] Modifying a `src/` file triggers automatic restart
- [ ] `make test` runs E2E tests against a clean database and exits
- [ ] `docker compose up` on a clean machine with only Docker works end-to-end


🤖 Generated with [Claude Code](https://claude.com/claude-code)