### PR TITLE
feat: add payment amount and daily limit validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,14 @@ ALLOWED_ORIGINS=http://localhost:3000,https://app.facilpay.com
 # Set to "true" to allow credentials (cookies, auth headers)
 CORS_CREDENTIALS=true
 
+# Payment Amount Limits
+# Minimum payment amount (default: 0.01)
+PAYMENT_MIN_AMOUNT=0.01
+# Maximum payment amount (leave unset for no limit)
+# PAYMENT_MAX_AMOUNT=10000
+# Maximum cumulative daily payment amount per user (leave unset for no limit)
+# PAYMENT_DAILY_LIMIT_PER_USER=50000
+
 # Idempotency Configuration
 # Time-to-live for idempotency keys in hours (default: 24)
 IDEMPOTENCY_TTL_HOURS=24

--- a/src/common/validators/is-within-payment-limits.validator.ts
+++ b/src/common/validators/is-within-payment-limits.validator.ts
@@ -1,0 +1,36 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+@ValidatorConstraint({ name: 'isWithinPaymentLimits', async: false })
+export class IsWithinPaymentLimitsConstraint implements ValidatorConstraintInterface {
+  validate(amount: number): boolean {
+    const min = Number(process.env.PAYMENT_MIN_AMOUNT ?? 0.01);
+    const max = Number(process.env.PAYMENT_MAX_AMOUNT ?? Infinity);
+    return amount >= min && amount <= max;
+  }
+
+  defaultMessage(): string {
+    const min = process.env.PAYMENT_MIN_AMOUNT ?? '0.01';
+    const max = process.env.PAYMENT_MAX_AMOUNT;
+    if (max) {
+      return `Amount must be between ${min} and ${max}`;
+    }
+    return `Amount must be at least ${min}`;
+  }
+}
+
+export function IsWithinPaymentLimits(options?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options,
+      constraints: [],
+      validator: IsWithinPaymentLimitsConstraint,
+    });
+  };
+}

--- a/src/migrations/1706600000000-AddUserIdToPayments.ts
+++ b/src/migrations/1706600000000-AddUserIdToPayments.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUserIdToPayments1706600000000 implements MigrationInterface {
+  name = 'AddUserIdToPayments1706600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "payments" ADD COLUMN IF NOT EXISTS "userId" uuid`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_payments_user_id" ON "payments" ("userId")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_payments_user_id"`);
+    await queryRunner.query(`ALTER TABLE "payments" DROP COLUMN IF EXISTS "userId"`);
+  }
+}

--- a/src/modules/payments/dto/create-payment.dto.ts
+++ b/src/modules/payments/dto/create-payment.dto.ts
@@ -9,6 +9,7 @@ import {
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsISO4217CurrencyCode } from '../../../common/validators/is-iso4217-currency-code.validator';
+import { IsWithinPaymentLimits } from '../../../common/validators/is-within-payment-limits.validator';
 
 
 export class CreatePaymentDto {
@@ -16,8 +17,9 @@ export class CreatePaymentDto {
   @IsNotEmpty()
   @IsPositive({ message: 'Amount must be a positive number' })
   @Min(0.01, { message: 'Amount must be at least 0.01' })
+  @IsWithinPaymentLimits()
   @ApiProperty({
-    description: 'Payment amount (must be positive)',
+    description: 'Payment amount. Must be within the configured PAYMENT_MIN_AMOUNT and PAYMENT_MAX_AMOUNT limits.',
     example: 100.5,
     minimum: 0.01,
   })

--- a/src/modules/payments/payment.entity.ts
+++ b/src/modules/payments/payment.entity.ts
@@ -34,6 +34,9 @@ export class Payment {
   status: PaymentStatus;
 
   @Column({ nullable: true })
+  userId: string | null = null;
+
+  @Column({ nullable: true })
   externalReference: string;
 
   @Column({ nullable: true })

--- a/src/modules/payments/payments.module.ts
+++ b/src/modules/payments/payments.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
 import { PaymentsService } from './payments.service';
 import { PaymentsController } from './payments.controller';
 import { Payment } from './payment.entity';
@@ -14,7 +15,7 @@ import { CurrenciesController } from './currencies.controller';
 
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Payment, Refund, IdempotencyKey])],
+  imports: [TypeOrmModule.forFeature([Payment, Refund, IdempotencyKey]), ConfigModule],
   controllers: [PaymentsController, CurrenciesController],
 
   providers: [

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import { Injectable, NotFoundException, ConflictException, UnprocessableEntityException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, Repository, LessThanOrEqual, MoreThanOrEqual, Like, Between } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { DataSource, Repository, LessThanOrEqual, MoreThanOrEqual, Like, Between, MoreThan } from 'typeorm';
 import { Payment, PaymentStatus } from './payment.entity';
 import { Refund } from './refund.entity';
 import { CreatePaymentDto } from './dto/create-payment.dto';
@@ -14,6 +15,9 @@ import { IdempotencyService } from './idempotency.service';
 @Injectable()
 export class PaymentsService {
   private readonly logger: Logger;
+  private readonly minAmount: number;
+  private readonly maxAmount: number;
+  private readonly dailyLimitPerUser: number;
 
   constructor(
     @InjectRepository(Payment)
@@ -23,8 +27,48 @@ export class PaymentsService {
     private readonly dataSource: DataSource,
     appLogger: AppLogger,
     private readonly idempotencyService: IdempotencyService,
+    private readonly configService: ConfigService,
   ) {
     this.logger = appLogger.child({ module: PaymentsService.name });
+    this.minAmount = this.configService.get<number>('PAYMENT_MIN_AMOUNT', 0.01);
+    this.maxAmount = this.configService.get<number>('PAYMENT_MAX_AMOUNT', Infinity);
+    this.dailyLimitPerUser = this.configService.get<number>('PAYMENT_DAILY_LIMIT_PER_USER', Infinity);
+  }
+
+  private async checkPaymentLimits(amount: number, userId?: string): Promise<void> {
+    if (amount < this.minAmount) {
+      throw new UnprocessableEntityException(
+        `Payment amount ${amount} is below the minimum allowed amount of ${this.minAmount}`,
+      );
+    }
+    if (amount > this.maxAmount) {
+      throw new UnprocessableEntityException(
+        `Payment amount ${amount} exceeds the maximum allowed amount of ${this.maxAmount}`,
+      );
+    }
+
+    if (userId && isFinite(this.dailyLimitPerUser)) {
+      const startOfDay = new Date();
+      startOfDay.setHours(0, 0, 0, 0);
+
+      const result = await this.paymentRepository
+        .createQueryBuilder('p')
+        .select('COALESCE(SUM(p.amount), 0)', 'total')
+        .where('p.userId = :userId', { userId })
+        .andWhere('p.createdAt >= :startOfDay', { startOfDay })
+        .andWhere('p.status NOT IN (:...excluded)', {
+          excluded: [PaymentStatus.FAILED, PaymentStatus.CANCELLED],
+        })
+        .getRawOne<{ total: string }>();
+
+      const dailySpend = Number(result?.total ?? 0);
+      if (dailySpend + amount > this.dailyLimitPerUser) {
+        throw new UnprocessableEntityException(
+          `This payment would exceed your daily limit of ${this.dailyLimitPerUser}. ` +
+          `Current daily spend: ${dailySpend.toFixed(2)}`,
+        );
+      }
+    }
   }
 
   /**
@@ -37,7 +81,10 @@ export class PaymentsService {
   async create(
     createPaymentDto: CreatePaymentDto,
     idempotencyKey?: string,
+    userId?: string,
   ): Promise<Payment> {
+    await this.checkPaymentLimits(createPaymentDto.amount, userId);
+
     // Check for existing idempotency key
     if (idempotencyKey) {
       const cachedResponse = await this.idempotencyService.checkIdempotencyKey(
@@ -62,6 +109,7 @@ export class PaymentsService {
       const payment = queryRunner.manager.create(Payment, {
         ...createPaymentDto,
         status: PaymentStatus.PENDING,
+        userId: userId ?? null,
       });
 
       const savedPayment = await queryRunner.manager.save(payment);


### PR DESCRIPTION
## Summary

- **Per-transaction limits**: `PAYMENT_MIN_AMOUNT` / `PAYMENT_MAX_AMOUNT` env vars; validated at DTO level via custom `IsWithinPaymentLimits` decorator
- **Daily cumulative limit**: `PAYMENT_DAILY_LIMIT_PER_USER` — checked in `PaymentsService.create()` by querying today's non-failed/non-cancelled payments for the user
- All breaches return **422 Unprocessable Entity** with a descriptive message
- All three limits are configurable via env variables with sensible defaults (no upper cap by default)
- Add `userId` (nullable) to `Payment` entity + CONCURRENTLY migration + index

## Changes

- `src/common/validators/is-within-payment-limits.validator.ts` — custom class-validator constraint
- `src/modules/payments/dto/create-payment.dto.ts` — apply `@IsWithinPaymentLimits()`
- `src/modules/payments/payments.service.ts` — `checkPaymentLimits()` + `ConfigService` injection
- `src/modules/payments/payments.module.ts` — import `ConfigModule`
- `src/modules/payments/payment.entity.ts` — add `userId` column
- `src/migrations/1706600000000-AddUserIdToPayments.ts` — migration
- `.env.example` — document limit vars

## Test plan

- [ ] Amount below `PAYMENT_MIN_AMOUNT` → 422
- [ ] Amount above `PAYMENT_MAX_AMOUNT` → 422
- [ ] Payments that would exceed `PAYMENT_DAILY_LIMIT_PER_USER` → 422 with remaining amount shown
- [ ] Limits configurable without code changes via env vars


🤖 Generated with [Claude Code](https://claude.com/claude-code)