### PR TITLE
feat: implement webhook retry mechanism with exponential backoff

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { HttpLoggerMiddleware } from './modules/logger/http-logger.middleware';
 import { ThrottlerConfigModule } from './modules/throttler/throttler.config.module';
 import { StellarModule } from './modules/stellar/stellar.module';
 import { CorsModule } from './modules/cors/cors.module';
+import { WebhooksModule } from './modules/webhooks/webhooks.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { CorsModule } from './modules/cors/cors.module';
     AuthModule,
     PaymentsModule,
     StellarModule,
+    WebhooksModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/migrations/1706700000000-CreateWebhookDeliveriesTable.ts
+++ b/src/migrations/1706700000000-CreateWebhookDeliveriesTable.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateWebhookDeliveriesTable1706700000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "webhook_deliveries_eventtype_enum" AS ENUM (
+        'payment.created',
+        'payment.completed',
+        'payment.failed',
+        'payment.cancelled',
+        'payment.refunded'
+      );
+
+      CREATE TYPE "webhook_deliveries_status_enum" AS ENUM (
+        'PENDING',
+        'SUCCESS',
+        'FAILED',
+        'EXHAUSTED'
+      );
+
+      CREATE TABLE "webhook_deliveries" (
+        "id"             UUID                                  NOT NULL DEFAULT uuid_generate_v4(),
+        "paymentId"      UUID                                  NOT NULL,
+        "url"            VARCHAR                               NOT NULL,
+        "eventType"      "webhook_deliveries_eventtype_enum"   NOT NULL,
+        "payload"        JSONB                                 NOT NULL,
+        "status"         "webhook_deliveries_status_enum"      NOT NULL DEFAULT 'PENDING',
+        "attemptCount"   INTEGER                               NOT NULL DEFAULT 0,
+        "maxAttempts"    INTEGER                               NOT NULL DEFAULT 5,
+        "lastHttpStatus" INTEGER,
+        "lastError"      TEXT,
+        "nextRetryAt"    TIMESTAMPTZ,
+        "lastAttemptAt"  TIMESTAMPTZ,
+        "createdAt"      TIMESTAMPTZ                           NOT NULL DEFAULT now(),
+        "updatedAt"      TIMESTAMPTZ                           NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_webhook_deliveries" PRIMARY KEY ("id")
+      );
+
+      CREATE INDEX "idx_webhook_deliveries_payment_id" ON "webhook_deliveries" ("paymentId");
+      CREATE INDEX "idx_webhook_deliveries_status"     ON "webhook_deliveries" ("status");
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP TABLE IF EXISTS "webhook_deliveries";
+      DROP TYPE IF EXISTS "webhook_deliveries_status_enum";
+      DROP TYPE IF EXISTS "webhook_deliveries_eventtype_enum";
+    `);
+  }
+}

--- a/src/modules/webhooks/webhook-deliveries.controller.ts
+++ b/src/modules/webhooks/webhook-deliveries.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Get, Param, Post, HttpCode, HttpStatus } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiParam,
+  ApiOkResponse,
+  ApiNotFoundResponse,
+} from '@nestjs/swagger';
+import { WebhookRetryService } from './webhook-retry.service';
+
+@ApiTags('webhooks')
+@Controller('v1/webhooks')
+export class WebhookDeliveriesController {
+  constructor(private readonly webhookRetryService: WebhookRetryService) {}
+
+  @Get('deliveries/:paymentId')
+  @ApiOperation({
+    summary: 'List webhook deliveries for a payment',
+    description:
+      'Returns all outbound webhook delivery attempts for a given payment, including retry history.',
+  })
+  @ApiParam({ name: 'paymentId', description: 'Payment UUID' })
+  @ApiOkResponse({ description: 'List of webhook deliveries.' })
+  getDeliveries(@Param('paymentId') paymentId: string) {
+    return this.webhookRetryService.getDeliveries(paymentId);
+  }
+
+  @Post('retry-pending')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Manually trigger retry of pending webhook deliveries',
+    description:
+      'Picks up all failed webhook deliveries whose next retry time has passed and attempts redelivery.',
+  })
+  @ApiOkResponse({ description: 'Retry sweep triggered.' })
+  async retryPending() {
+    await this.webhookRetryService.retryPendingDeliveries();
+    return { message: 'Retry sweep completed' };
+  }
+}

--- a/src/modules/webhooks/webhook-delivery.entity.ts
+++ b/src/modules/webhooks/webhook-delivery.entity.ts
@@ -1,0 +1,74 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum WebhookDeliveryStatus {
+  PENDING = 'PENDING',
+  SUCCESS = 'SUCCESS',
+  FAILED = 'FAILED',
+  EXHAUSTED = 'EXHAUSTED',
+}
+
+export enum WebhookEventType {
+  PAYMENT_CREATED = 'payment.created',
+  PAYMENT_COMPLETED = 'payment.completed',
+  PAYMENT_FAILED = 'payment.failed',
+  PAYMENT_CANCELLED = 'payment.cancelled',
+  PAYMENT_REFUNDED = 'payment.refunded',
+}
+
+@Entity('webhook_deliveries')
+export class WebhookDelivery {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index('idx_webhook_deliveries_payment_id')
+  @Column({ type: 'uuid' })
+  paymentId: string;
+
+  @Column()
+  url: string;
+
+  @Column({ type: 'enum', enum: WebhookEventType })
+  eventType: WebhookEventType;
+
+  @Column({ type: 'jsonb' })
+  payload: Record<string, unknown>;
+
+  @Column({
+    type: 'enum',
+    enum: WebhookDeliveryStatus,
+    default: WebhookDeliveryStatus.PENDING,
+  })
+  @Index('idx_webhook_deliveries_status')
+  status: WebhookDeliveryStatus;
+
+  @Column({ default: 0 })
+  attemptCount: number;
+
+  @Column({ default: 5 })
+  maxAttempts: number;
+
+  @Column({ type: 'int', nullable: true })
+  lastHttpStatus: number | null;
+
+  @Column({ type: 'text', nullable: true })
+  lastError: string | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  nextRetryAt: Date | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  lastAttemptAt: Date | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/webhooks/webhook-retry.service.ts
+++ b/src/modules/webhooks/webhook-retry.service.ts
@@ -1,0 +1,168 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThanOrEqual } from 'typeorm';
+import * as https from 'https';
+import * as http from 'http';
+import {
+  WebhookDelivery,
+  WebhookDeliveryStatus,
+  WebhookEventType,
+} from './webhook-delivery.entity';
+
+const BASE_DELAY_MS = 1000;
+const MAX_DELAY_MS = 3600_000; // 1 hour cap
+
+function exponentialDelay(attempt: number): number {
+  const jitter = Math.random() * 1000;
+  return Math.min(BASE_DELAY_MS * Math.pow(2, attempt) + jitter, MAX_DELAY_MS);
+}
+
+@Injectable()
+export class WebhookRetryService {
+  private readonly logger = new Logger(WebhookRetryService.name);
+
+  constructor(
+    @InjectRepository(WebhookDelivery)
+    private readonly deliveryRepository: Repository<WebhookDelivery>,
+  ) {}
+
+  async schedule(
+    paymentId: string,
+    url: string,
+    eventType: WebhookEventType,
+    payload: Record<string, unknown>,
+    maxAttempts = 5,
+  ): Promise<WebhookDelivery> {
+    const delivery = this.deliveryRepository.create({
+      paymentId,
+      url,
+      eventType,
+      payload,
+      maxAttempts,
+      status: WebhookDeliveryStatus.PENDING,
+      nextRetryAt: new Date(),
+    });
+    const saved = await this.deliveryRepository.save(delivery);
+    this.logger.log(`Scheduled webhook delivery ${saved.id} for ${eventType}`);
+    setImmediate(() => this.attemptDelivery(saved.id));
+    return saved;
+  }
+
+  async attemptDelivery(deliveryId: string): Promise<void> {
+    const delivery = await this.deliveryRepository.findOneBy({ id: deliveryId });
+    if (!delivery) return;
+
+    if (
+      delivery.status === WebhookDeliveryStatus.SUCCESS ||
+      delivery.status === WebhookDeliveryStatus.EXHAUSTED
+    ) {
+      return;
+    }
+
+    delivery.attemptCount += 1;
+    delivery.lastAttemptAt = new Date();
+
+    try {
+      const statusCode = await this.post(delivery.url, delivery.payload);
+      delivery.lastHttpStatus = statusCode;
+
+      if (statusCode >= 200 && statusCode < 300) {
+        delivery.status = WebhookDeliveryStatus.SUCCESS;
+        delivery.nextRetryAt = null;
+        this.logger.log(
+          `Webhook ${delivery.id} delivered (attempt ${delivery.attemptCount})`,
+        );
+      } else {
+        throw new Error(`HTTP ${statusCode}`);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      delivery.lastError = message;
+      this.logger.warn(
+        `Webhook ${delivery.id} attempt ${delivery.attemptCount} failed: ${message}`,
+      );
+
+      if (delivery.attemptCount >= delivery.maxAttempts) {
+        delivery.status = WebhookDeliveryStatus.EXHAUSTED;
+        delivery.nextRetryAt = null;
+        this.logger.error(
+          `Webhook ${delivery.id} exhausted after ${delivery.attemptCount} attempts`,
+        );
+      } else {
+        delivery.status = WebhookDeliveryStatus.FAILED;
+        const delayMs = exponentialDelay(delivery.attemptCount);
+        delivery.nextRetryAt = new Date(Date.now() + delayMs);
+        this.scheduleRetry(delivery.id, delayMs);
+      }
+    }
+
+    await this.deliveryRepository.save(delivery);
+  }
+
+  private scheduleRetry(deliveryId: string, delayMs: number): void {
+    setTimeout(() => {
+      this.attemptDelivery(deliveryId).catch((err) => {
+        this.logger.error(`Retry failed for ${deliveryId}: ${err.message}`);
+      });
+    }, delayMs);
+  }
+
+  async retryPendingDeliveries(): Promise<void> {
+    const due = await this.deliveryRepository.find({
+      where: {
+        status: WebhookDeliveryStatus.FAILED,
+        nextRetryAt: LessThanOrEqual(new Date()),
+      },
+      take: 100,
+    });
+
+    for (const delivery of due) {
+      await this.attemptDelivery(delivery.id);
+    }
+  }
+
+  async getDeliveries(
+    paymentId: string,
+  ): Promise<WebhookDelivery[]> {
+    return this.deliveryRepository.find({
+      where: { paymentId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  private post(
+    url: string,
+    body: Record<string, unknown>,
+  ): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const data = JSON.stringify(body);
+      const parsed = new URL(url);
+      const isHttps = parsed.protocol === 'https:';
+      const lib = isHttps ? https : http;
+
+      const req = lib.request(
+        {
+          hostname: parsed.hostname,
+          port: parsed.port || (isHttps ? 443 : 80),
+          path: parsed.pathname + parsed.search,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(data),
+            'User-Agent': 'FacilPay-Webhooks/1.0',
+          },
+          timeout: 10_000,
+        },
+        (res) => resolve(res.statusCode ?? 0),
+      );
+
+      req.on('error', reject);
+      req.on('timeout', () => {
+        req.destroy();
+        reject(new Error('Request timed out after 10s'));
+      });
+      req.write(data);
+      req.end();
+    });
+  }
+}

--- a/src/modules/webhooks/webhooks.module.ts
+++ b/src/modules/webhooks/webhooks.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { WebhookDelivery } from './webhook-delivery.entity';
+import { WebhookRetryService } from './webhook-retry.service';
+import { WebhookDeliveriesController } from './webhook-deliveries.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([WebhookDelivery])],
+  controllers: [WebhookDeliveriesController],
+  providers: [WebhookRetryService],
+  exports: [WebhookRetryService],
+})
+export class WebhooksModule {}


### PR DESCRIPTION
## Summary

- Implements outbound webhook delivery tracking with `WebhookDelivery` entity
- Exponential backoff retry: `base=1s * 2^attempt + jitter`, capped at 1 hour
- Max 5 attempts per delivery; terminal state `EXHAUSTED` on exhaustion
- `POST /v1/webhooks/retry-pending` — manual sweep for overdue retries
- `GET /v1/webhooks/deliveries/:paymentId` — inspect full delivery history
- Migration `1706700000000-CreateWebhookDeliveriesTable`

## Test plan

- [ ] Schedule a webhook delivery to a test URL and verify `attemptCount` increments on failure
- [ ] Verify `nextRetryAt` follows exponential delay after each failed attempt
- [ ] Confirm `EXHAUSTED` status after 5 failed attempts
- [ ] Verify successful delivery sets status to `SUCCESS`
- [ ] Call `POST /v1/webhooks/retry-pending` and confirm overdue FAILED deliveries are retried


🤖 Generated with [Claude Code](https://claude.com/claude-code)