### PR TITLE
feat: add request timeout and circuit breaker for external calls

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,10 +12,12 @@ import { HttpLoggerMiddleware } from './modules/logger/http-logger.middleware';
 import { ThrottlerConfigModule } from './modules/throttler/throttler.config.module';
 import { StellarModule } from './modules/stellar/stellar.module';
 import { CorsModule } from './modules/cors/cors.module';
+import { CircuitBreakerModule } from './modules/circuit-breaker/circuit-breaker.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
+    CircuitBreakerModule,
     ThrottlerConfigModule,
     LoggerModule,
     CorsModule,

--- a/src/common/utils/with-timeout.ts
+++ b/src/common/utils/with-timeout.ts
@@ -1,0 +1,16 @@
+import { RequestTimeoutException } from '@nestjs/common';
+
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label = 'operation',
+): Promise<T> {
+  let timer: NodeJS.Timeout;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new RequestTimeoutException(`${label} timed out after ${ms}ms`)),
+      ms,
+    );
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}

--- a/src/modules/circuit-breaker/circuit-breaker.controller.ts
+++ b/src/modules/circuit-breaker/circuit-breaker.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Param, HttpCode, HttpStatus } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiOkResponse, ApiParam } from '@nestjs/swagger';
+import { CircuitBreakerService } from './circuit-breaker.service';
+
+@ApiTags('circuit-breaker')
+@Controller('v1/circuit-breaker')
+export class CircuitBreakerController {
+  constructor(private readonly cb: CircuitBreakerService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get all circuit breaker states' })
+  @ApiOkResponse({ description: 'Map of circuit name to current state.' })
+  getAllStates() {
+    return this.cb.getAllStates();
+  }
+
+  @Get(':name')
+  @ApiOperation({ summary: 'Get state of a named circuit' })
+  @ApiParam({ name: 'name', example: 'stellar-horizon' })
+  @ApiOkResponse({ description: 'Circuit state.' })
+  getState(@Param('name') name: string) {
+    return this.cb.getState(name) ?? { state: 'UNKNOWN' };
+  }
+
+  @Post(':name/reset')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Manually reset a named circuit to CLOSED' })
+  @ApiParam({ name: 'name', example: 'stellar-horizon' })
+  @ApiOkResponse({ description: 'Circuit reset.' })
+  reset(@Param('name') name: string) {
+    this.cb.reset(name);
+    return { message: `Circuit '${name}' reset to CLOSED` };
+  }
+}

--- a/src/modules/circuit-breaker/circuit-breaker.module.ts
+++ b/src/modules/circuit-breaker/circuit-breaker.module.ts
@@ -1,0 +1,11 @@
+import { Module, Global } from '@nestjs/common';
+import { CircuitBreakerService } from './circuit-breaker.service';
+import { CircuitBreakerController } from './circuit-breaker.controller';
+
+@Global()
+@Module({
+  controllers: [CircuitBreakerController],
+  providers: [CircuitBreakerService],
+  exports: [CircuitBreakerService],
+})
+export class CircuitBreakerModule {}

--- a/src/modules/circuit-breaker/circuit-breaker.service.ts
+++ b/src/modules/circuit-breaker/circuit-breaker.service.ts
@@ -1,0 +1,134 @@
+import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common';
+
+export enum CircuitState {
+  CLOSED = 'CLOSED',
+  OPEN = 'OPEN',
+  HALF_OPEN = 'HALF_OPEN',
+}
+
+export interface CircuitBreakerOptions {
+  failureThreshold?: number;
+  successThreshold?: number;
+  timeout?: number;
+  halfOpenRequests?: number;
+}
+
+interface CircuitStats {
+  state: CircuitState;
+  failures: number;
+  successes: number;
+  halfOpenSuccesses: number;
+  lastFailureAt: number | null;
+  openedAt: number | null;
+}
+
+const DEFAULT_OPTS: Required<CircuitBreakerOptions> = {
+  failureThreshold: 5,
+  successThreshold: 2,
+  timeout: 60_000,
+  halfOpenRequests: 1,
+};
+
+@Injectable()
+export class CircuitBreakerService {
+  private readonly logger = new Logger(CircuitBreakerService.name);
+  private readonly circuits = new Map<string, CircuitStats>();
+
+  private getOrCreate(name: string): CircuitStats {
+    if (!this.circuits.has(name)) {
+      this.circuits.set(name, {
+        state: CircuitState.CLOSED,
+        failures: 0,
+        successes: 0,
+        halfOpenSuccesses: 0,
+        lastFailureAt: null,
+        openedAt: null,
+      });
+    }
+    return this.circuits.get(name)!;
+  }
+
+  async execute<T>(
+    name: string,
+    fn: () => Promise<T>,
+    opts: CircuitBreakerOptions = {},
+  ): Promise<T> {
+    const o = { ...DEFAULT_OPTS, ...opts };
+    const circuit = this.getOrCreate(name);
+
+    if (circuit.state === CircuitState.OPEN) {
+      const elapsed = Date.now() - (circuit.openedAt ?? 0);
+      if (elapsed >= o.timeout) {
+        circuit.state = CircuitState.HALF_OPEN;
+        circuit.halfOpenSuccesses = 0;
+        this.logger.log(`Circuit '${name}' transitioned to HALF_OPEN`);
+      } else {
+        throw new ServiceUnavailableException(
+          `Circuit '${name}' is OPEN — service unavailable`,
+        );
+      }
+    }
+
+    try {
+      const result = await fn();
+      this.onSuccess(name, circuit, o);
+      return result;
+    } catch (err) {
+      this.onFailure(name, circuit, o);
+      throw err;
+    }
+  }
+
+  private onSuccess(
+    name: string,
+    circuit: CircuitStats,
+    o: Required<CircuitBreakerOptions>,
+  ) {
+    circuit.failures = 0;
+    if (circuit.state === CircuitState.HALF_OPEN) {
+      circuit.halfOpenSuccesses += 1;
+      if (circuit.halfOpenSuccesses >= o.successThreshold) {
+        circuit.state = CircuitState.CLOSED;
+        circuit.openedAt = null;
+        this.logger.log(`Circuit '${name}' closed after recovery`);
+      }
+    } else {
+      circuit.successes += 1;
+    }
+  }
+
+  private onFailure(
+    name: string,
+    circuit: CircuitStats,
+    o: Required<CircuitBreakerOptions>,
+  ) {
+    circuit.failures += 1;
+    circuit.lastFailureAt = Date.now();
+
+    if (
+      circuit.state === CircuitState.HALF_OPEN ||
+      circuit.failures >= o.failureThreshold
+    ) {
+      circuit.state = CircuitState.OPEN;
+      circuit.openedAt = Date.now();
+      this.logger.warn(
+        `Circuit '${name}' opened after ${circuit.failures} failures`,
+      );
+    }
+  }
+
+  getState(name: string): CircuitStats | undefined {
+    return this.circuits.get(name);
+  }
+
+  reset(name: string): void {
+    this.circuits.delete(name);
+    this.logger.log(`Circuit '${name}' manually reset`);
+  }
+
+  getAllStates(): Record<string, CircuitStats> {
+    const result: Record<string, CircuitStats> = {};
+    this.circuits.forEach((v, k) => (result[k] = v));
+    return result;
+  }
+}

--- a/src/modules/stellar/stellar.service.ts
+++ b/src/modules/stellar/stellar.service.ts
@@ -1,6 +1,11 @@
 import { Injectable, Logger, InternalServerErrorException, BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as StellarSdk from '@stellar/stellar-sdk';
+import { CircuitBreakerService } from '../circuit-breaker/circuit-breaker.service';
+import { withTimeout } from '../../common/utils/with-timeout';
+
+const CIRCUIT_NAME = 'stellar-horizon';
+const REQUEST_TIMEOUT_MS = 30_000;
 
 @Injectable()
 export class StellarService {
@@ -9,37 +14,50 @@ export class StellarService {
   private readonly networkPassphrase: string;
   private readonly sourceKeypair: StellarSdk.Keypair;
 
-  constructor(private configService: ConfigService) {
-  const horizonUrl = this.configService.get<string>('STELLAR_HORIZON_URL');
-  const network = this.configService.get<string>('STELLAR_NETWORK');
-  const secret = this.configService.get<string>('STELLAR_SOURCE_SECRET');
+  constructor(
+    private configService: ConfigService,
+    private readonly circuitBreaker: CircuitBreakerService,
+  ) {
+    const horizonUrl = this.configService.get<string>('STELLAR_HORIZON_URL');
+    const network = this.configService.get<string>('STELLAR_NETWORK');
+    const secret = this.configService.get<string>('STELLAR_SOURCE_SECRET');
 
-  // Throw an error if config is missing
-  if (!horizonUrl || !secret) {
-    throw new Error('Stellar configuration is missing. Check STELLAR_HORIZON_URL and STELLAR_SOURCE_SECRET in .env');
+    if (!horizonUrl || !secret) {
+      throw new Error(
+        'Stellar configuration is missing. Check STELLAR_HORIZON_URL and STELLAR_SOURCE_SECRET in .env',
+      );
+    }
+
+    this.server = new StellarSdk.Horizon.Server(horizonUrl);
+    this.networkPassphrase =
+      network === 'PUBLIC'
+        ? StellarSdk.Networks.PUBLIC
+        : StellarSdk.Networks.TESTNET;
+
+    this.sourceKeypair = StellarSdk.Keypair.fromSecret(secret);
   }
 
-  this.server = new StellarSdk.Horizon.Server(horizonUrl);
-  this.networkPassphrase = network === 'PUBLIC' 
-    ? StellarSdk.Networks.PUBLIC 
-    : StellarSdk.Networks.TESTNET;
-  
-  this.sourceKeypair = StellarSdk.Keypair.fromSecret(secret);
-}
-
-  /**
-   * Submits a simple XLM payment
-   */
   async sendPayment(destination: string, amount: string, memo?: string) {
-    try {
-      // 1. Load source account to get current sequence number
-      const sourceAccount = await this.server.loadAccount(this.sourceKeypair.publicKey());
+    return this.circuitBreaker.execute(
+      CIRCUIT_NAME,
+      () => withTimeout(this.doSendPayment(destination, amount, memo), REQUEST_TIMEOUT_MS, 'Stellar sendPayment'),
+      { failureThreshold: 3, timeout: 120_000 },
+    );
+  }
 
-      // 2. Build the transaction
-      let transactionBuilder = new StellarSdk.TransactionBuilder(sourceAccount, {
-        fee: this.configService.get<string>('STELLAR_BASE_FEE', '100'),
-        networkPassphrase: this.networkPassphrase,
-      })
+  private async doSendPayment(destination: string, amount: string, memo?: string) {
+    try {
+      const sourceAccount = await this.server.loadAccount(
+        this.sourceKeypair.publicKey(),
+      );
+
+      let transactionBuilder = new StellarSdk.TransactionBuilder(
+        sourceAccount,
+        {
+          fee: this.configService.get<string>('STELLAR_BASE_FEE', '100'),
+          networkPassphrase: this.networkPassphrase,
+        },
+      )
         .addOperation(
           StellarSdk.Operation.payment({
             destination,
@@ -50,44 +68,47 @@ export class StellarService {
         .setTimeout(30);
 
       if (memo) {
-        transactionBuilder = transactionBuilder.addMemo(StellarSdk.Memo.text(memo));
+        transactionBuilder = transactionBuilder.addMemo(
+          StellarSdk.Memo.text(memo),
+        );
       }
 
       const transaction = transactionBuilder.build();
-
-      // 3. Sign the transaction
       transaction.sign(this.sourceKeypair);
 
-      // 4. Submit to Horizon
       const response = await this.server.submitTransaction(transaction);
-      
+
       this.logger.log(`Payment successful: ${response.hash}`);
       return {
         hash: response.hash,
         ledger: response.ledger,
       };
-
     } catch (error) {
       this.handleStellarError(error);
     }
   }
 
-  private handleStellarError(error: any) {
-    const resultCodes = error.response?.data?.extras?.result_codes;
-    this.logger.error('Stellar Transaction Failed', resultCodes || error.message);
+  private handleStellarError(error: unknown): never {
+    const err = error as { response?: { data?: { extras?: { result_codes?: { operations?: string[]; transaction?: string }; }; detail?: string; }; }; message?: string };
+    const resultCodes = err.response?.data?.extras?.result_codes;
+    this.logger.error('Stellar Transaction Failed', resultCodes || err.message);
 
     if (resultCodes) {
-      // Mapping common Stellar errors to HTTP responses
-      if (resultCodes.operations?.includes('op_low_reserve') || resultCodes.transaction === 'tx_insufficient_balance') {
+      if (
+        resultCodes.operations?.includes('op_low_reserve') ||
+        resultCodes.transaction === 'tx_insufficient_balance'
+      ) {
         throw new BadRequestException('Insufficient Stellar account balance.');
       }
       if (resultCodes.transaction === 'tx_bad_seq') {
-        throw new InternalServerErrorException('Transaction sequence mismatch. Please retry.');
+        throw new InternalServerErrorException(
+          'Transaction sequence mismatch. Please retry.',
+        );
       }
     }
 
     throw new InternalServerErrorException(
-      error.response?.data?.detail || 'Blockchain transaction failed',
+      err.response?.data?.detail || 'Blockchain transaction failed',
     );
   }
 }


### PR DESCRIPTION
## Summary

- `CircuitBreakerService` implements CLOSED → OPEN → HALF_OPEN state machine
- Per-circuit config: `failureThreshold` (default 5), `successThreshold` (default 2), `timeout` (default 60s)
- `withTimeout(promise, ms)` utility rejects with `408 RequestTimeoutException` on deadline
- `StellarService.sendPayment()` protected: 3-failure threshold, 2-minute recovery window, 30s timeout
- `GET /v1/circuit-breaker` — see all circuit states
- `GET /v1/circuit-breaker/:name` — state for one circuit
- `POST /v1/circuit-breaker/:name/reset` — manually close a circuit
- `@Global()` module so any NestJS service can inject `CircuitBreakerService`

## Test plan

- [ ] Trigger 3+ Stellar failures and confirm circuit opens with 503
- [ ] Wait 2 minutes, confirm circuit enters HALF_OPEN and probes succeed
- [ ] Verify `GET /v1/circuit-breaker/stellar-horizon` reflects state changes
- [ ] Call `POST /v1/circuit-breaker/stellar-horizon/reset` and confirm circuit closes
- [ ] Verify a 30s+ Stellar call throws `RequestTimeoutException`


🤖 Generated with [Claude Code](https://claude.com/claude-code)