### PR TITLE
feat: implement payment reconciliation report endpoint

### DIFF
--- a/src/modules/payments/dto/reconciliation-query.dto.ts
+++ b/src/modules/payments/dto/reconciliation-query.dto.ts
@@ -1,0 +1,28 @@
+import { IsOptional, IsISO8601, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ReconciliationQueryDto {
+  @IsOptional()
+  @IsISO8601()
+  @ApiPropertyOptional({
+    description: 'Start of reporting period (ISO 8601)',
+    example: '2026-01-01T00:00:00Z',
+  })
+  from?: string;
+
+  @IsOptional()
+  @IsISO8601()
+  @ApiPropertyOptional({
+    description: 'End of reporting period (ISO 8601)',
+    example: '2026-01-31T23:59:59Z',
+  })
+  to?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({
+    description: 'Filter by currency (ISO 4217)',
+    example: 'USD',
+  })
+  currency?: string;
+}

--- a/src/modules/payments/payments.controller.ts
+++ b/src/modules/payments/payments.controller.ts
@@ -30,6 +30,8 @@ import {
 import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
 import { PaymentsService } from './payments.service';
+import { ReconciliationService } from './reconciliation.service';
+import { ReconciliationQueryDto } from './dto/reconciliation-query.dto';
 import { CreatePaymentDto } from './dto/create-payment.dto';
 import { BulkCreatePaymentsResponseDto } from './dto/bulk-create-payments-response.dto';
 import { RefundPaymentDto } from './dto/refund-payment.dto';
@@ -44,7 +46,10 @@ import { IdempotencyInterceptor } from './idempotency.interceptor';
 @ApiTags('payments')
 @Controller('v1/payments')
 export class PaymentsController {
-  constructor(private readonly paymentsService: PaymentsService) { }
+  constructor(
+    private readonly paymentsService: PaymentsService,
+    private readonly reconciliationService: ReconciliationService,
+  ) {}
 
   @Post()
   @UseInterceptors(IdempotencyInterceptor)
@@ -202,6 +207,38 @@ export class PaymentsController {
     }
 
     return this.paymentsService.findAll(getPaymentsDto);
+  }
+
+  @Get('reconciliation')
+  @ApiOperation({
+    summary: 'Generate payment reconciliation report',
+    description:
+      'Returns a breakdown of payment counts and amounts by status, plus refund totals, for a given time window and optional currency filter.',
+  })
+  @ApiOkResponse({
+    description: 'Reconciliation report generated.',
+    schema: {
+      example: {
+        period: { from: '2026-01-01T00:00:00Z', to: '2026-01-31T23:59:59Z' },
+        currency: 'USD',
+        generatedAt: '2026-02-01T00:00:00.000Z',
+        summary: {
+          totalPayments: 150,
+          totalAmount: 15000.0,
+          totalRefundedAmount: 500.0,
+          netAmount: 14500.0,
+        },
+        byStatus: [
+          { status: 'COMPLETED', count: 120, totalAmount: 12000.0 },
+          { status: 'PENDING', count: 20, totalAmount: 2000.0 },
+          { status: 'FAILED', count: 10, totalAmount: 1000.0 },
+        ],
+        refunds: { count: 5, totalAmount: 500.0 },
+      },
+    },
+  })
+  getReconciliation(@Query() query: ReconciliationQueryDto) {
+    return this.reconciliationService.generate(query);
   }
 
   @Get(':id')

--- a/src/modules/payments/payments.module.ts
+++ b/src/modules/payments/payments.module.ts
@@ -11,6 +11,7 @@ import { IdempotencyService } from './idempotency.service';
 import { IdempotencyInterceptor } from './idempotency.interceptor';
 import { CurrencyConfigService } from './currency-config.service';
 import { CurrenciesController } from './currencies.controller';
+import { ReconciliationService } from './reconciliation.service';
 
 
 @Module({
@@ -24,7 +25,8 @@ import { CurrenciesController } from './currencies.controller';
     IdempotencyService,
     IdempotencyInterceptor,
     CurrencyConfigService,
+    ReconciliationService,
   ],
-  exports: [PaymentsService, WebhookSignatureService, WebhookGuard],
+  exports: [PaymentsService, WebhookSignatureService, WebhookGuard, ReconciliationService],
 })
 export class PaymentsModule { }

--- a/src/modules/payments/reconciliation.service.ts
+++ b/src/modules/payments/reconciliation.service.ts
@@ -1,0 +1,109 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Payment, PaymentStatus } from './payment.entity';
+import { Refund } from './refund.entity';
+import { ReconciliationQueryDto } from './dto/reconciliation-query.dto';
+
+export interface StatusBreakdown {
+  status: PaymentStatus;
+  count: number;
+  totalAmount: number;
+}
+
+export interface ReconciliationReport {
+  period: { from: string | null; to: string | null };
+  currency: string | null;
+  generatedAt: string;
+  summary: {
+    totalPayments: number;
+    totalAmount: number;
+    totalRefundedAmount: number;
+    netAmount: number;
+  };
+  byStatus: StatusBreakdown[];
+  refunds: {
+    count: number;
+    totalAmount: number;
+  };
+}
+
+@Injectable()
+export class ReconciliationService {
+  constructor(
+    @InjectRepository(Payment)
+    private readonly paymentRepository: Repository<Payment>,
+    @InjectRepository(Refund)
+    private readonly refundRepository: Repository<Refund>,
+  ) {}
+
+  async generate(query: ReconciliationQueryDto): Promise<ReconciliationReport> {
+    const qb = this.paymentRepository
+      .createQueryBuilder('payment')
+      .select('payment.status', 'status')
+      .addSelect('COUNT(*)', 'count')
+      .addSelect('COALESCE(SUM(payment.amount), 0)', 'totalAmount')
+      .groupBy('payment.status');
+
+    if (query.from) {
+      qb.andWhere('payment.createdAt >= :from', { from: query.from });
+    }
+    if (query.to) {
+      qb.andWhere('payment.createdAt <= :to', { to: query.to });
+    }
+    if (query.currency) {
+      qb.andWhere('payment.currency = :currency', { currency: query.currency });
+    }
+
+    const rows: { status: PaymentStatus; count: string; totalAmount: string }[] =
+      await qb.getRawMany();
+
+    const byStatus: StatusBreakdown[] = rows.map((r) => ({
+      status: r.status,
+      count: parseInt(r.count, 10),
+      totalAmount: parseFloat(r.totalAmount),
+    }));
+
+    const totalPayments = byStatus.reduce((s, r) => s + r.count, 0);
+    const totalAmount = byStatus.reduce((s, r) => s + r.totalAmount, 0);
+
+    const refundQb = this.refundRepository
+      .createQueryBuilder('refund')
+      .select('COUNT(*)', 'count')
+      .addSelect('COALESCE(SUM(refund.amount), 0)', 'totalAmount')
+      .innerJoin('payments', 'p', 'p.id = refund."paymentId"');
+
+    if (query.from) {
+      refundQb.andWhere('refund."createdAt" >= :from', { from: query.from });
+    }
+    if (query.to) {
+      refundQb.andWhere('refund."createdAt" <= :to', { to: query.to });
+    }
+    if (query.currency) {
+      refundQb.andWhere('p.currency = :currency', { currency: query.currency });
+    }
+
+    const refundRow: { count: string; totalAmount: string } =
+      await refundQb.getRawOne();
+
+    const refundCount = parseInt(refundRow?.count ?? '0', 10);
+    const totalRefundedAmount = parseFloat(refundRow?.totalAmount ?? '0');
+
+    return {
+      period: { from: query.from ?? null, to: query.to ?? null },
+      currency: query.currency ?? null,
+      generatedAt: new Date().toISOString(),
+      summary: {
+        totalPayments,
+        totalAmount: parseFloat(totalAmount.toFixed(2)),
+        totalRefundedAmount: parseFloat(totalRefundedAmount.toFixed(2)),
+        netAmount: parseFloat((totalAmount - totalRefundedAmount).toFixed(2)),
+      },
+      byStatus,
+      refunds: {
+        count: refundCount,
+        totalAmount: parseFloat(totalRefundedAmount.toFixed(2)),
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- `ReconciliationService` aggregates payment counts/amounts grouped by status
- Cross-joins refund totals for the same period + currency
- `GET /v1/payments/reconciliation` — all query params optional: `from`, `to`, `currency`
- Response: `summary` (total/refunded/net), `byStatus[]`, `refunds` block
- Placed before `GET /v1/payments/:id` to avoid route shadowing

## Test plan

- [ ] Call without params — should return aggregates across all payments
- [ ] Call with `from` / `to` — verify counts match only that window
- [ ] Call with `currency=USD` — verify non-USD payments excluded
- [ ] Confirm `netAmount = totalAmount - totalRefundedAmount`
- [ ] Verify `byStatus` matches actual `SELECT ... GROUP BY status` counts


🤖 Generated with [Claude Code](https://claude.com/claude-code)