### PR TITLE
feat: add Stellar payment settlement integration

### DIFF
--- a/src/migrations/1706800000000-CreateStellarSettlementsTable.ts
+++ b/src/migrations/1706800000000-CreateStellarSettlementsTable.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateStellarSettlementsTable1706800000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "stellar_settlements_status_enum" AS ENUM (
+        'PENDING',
+        'SUBMITTED',
+        'CONFIRMED',
+        'FAILED'
+      );
+
+      CREATE TABLE "stellar_settlements" (
+        "id"                 UUID                                   NOT NULL DEFAULT uuid_generate_v4(),
+        "paymentId"          UUID                                   NOT NULL,
+        "destinationAddress" VARCHAR                                NOT NULL,
+        "xlmAmount"          VARCHAR                                NOT NULL,
+        "status"             "stellar_settlements_status_enum"      NOT NULL DEFAULT 'PENDING',
+        "transactionHash"    VARCHAR,
+        "ledger"             INTEGER,
+        "errorMessage"       TEXT,
+        "memo"               VARCHAR,
+        "createdAt"          TIMESTAMPTZ                            NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_stellar_settlements" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_stellar_settlements_payment_id" UNIQUE ("paymentId")
+      );
+
+      CREATE UNIQUE INDEX "idx_stellar_settlements_payment_id" ON "stellar_settlements" ("paymentId");
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP TABLE IF EXISTS "stellar_settlements";
+      DROP TYPE IF EXISTS "stellar_settlements_status_enum";
+    `);
+  }
+}

--- a/src/modules/payments/dto/settle-payment.dto.ts
+++ b/src/modules/payments/dto/settle-payment.dto.ts
@@ -1,0 +1,32 @@
+import { IsString, IsNotEmpty, Matches, IsOptional, MaxLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class SettlePaymentDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    description: 'Stellar destination account address (G... public key)',
+    example: 'GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3BHVJOVST',
+  })
+  destinationAddress: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^\d+(\.\d{1,7})?$/, {
+    message: 'xlmAmount must be a positive decimal with up to 7 decimal places',
+  })
+  @ApiProperty({
+    description: 'Amount of XLM to send (Stellar native asset)',
+    example: '10.5000000',
+  })
+  xlmAmount: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(28)
+  @ApiPropertyOptional({
+    description: 'Optional Stellar memo (max 28 characters)',
+    example: 'order-12345',
+  })
+  memo?: string;
+}

--- a/src/modules/payments/entities/stellar-settlement.entity.ts
+++ b/src/modules/payments/entities/stellar-settlement.entity.ts
@@ -1,0 +1,48 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum SettlementStatus {
+  PENDING = 'PENDING',
+  SUBMITTED = 'SUBMITTED',
+  CONFIRMED = 'CONFIRMED',
+  FAILED = 'FAILED',
+}
+
+@Entity('stellar_settlements')
+export class StellarSettlement {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index('idx_stellar_settlements_payment_id', { unique: true })
+  @Column({ type: 'uuid' })
+  paymentId: string;
+
+  @Column()
+  destinationAddress: string;
+
+  @Column({ type: 'varchar' })
+  xlmAmount: string;
+
+  @Column({ type: 'enum', enum: SettlementStatus, default: SettlementStatus.PENDING })
+  status: SettlementStatus;
+
+  @Column({ nullable: true })
+  transactionHash: string | null;
+
+  @Column({ type: 'int', nullable: true })
+  ledger: number | null;
+
+  @Column({ type: 'text', nullable: true })
+  errorMessage: string | null;
+
+  @Column({ nullable: true })
+  memo: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/modules/payments/payments.controller.ts
+++ b/src/modules/payments/payments.controller.ts
@@ -10,6 +10,7 @@ import {
   UseGuards,
   UseInterceptors,
   BadRequestException,
+  NotFoundException,
   Headers,
 } from '@nestjs/common';
 import {
@@ -30,6 +31,8 @@ import {
 import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
 import { PaymentsService } from './payments.service';
+import { SettlementService } from './settlement.service';
+import { SettlePaymentDto } from './dto/settle-payment.dto';
 import { CreatePaymentDto } from './dto/create-payment.dto';
 import { BulkCreatePaymentsResponseDto } from './dto/bulk-create-payments-response.dto';
 import { RefundPaymentDto } from './dto/refund-payment.dto';
@@ -44,7 +47,10 @@ import { IdempotencyInterceptor } from './idempotency.interceptor';
 @ApiTags('payments')
 @Controller('v1/payments')
 export class PaymentsController {
-  constructor(private readonly paymentsService: PaymentsService) { }
+  constructor(
+    private readonly paymentsService: PaymentsService,
+    private readonly settlementService: SettlementService,
+  ) {}
 
   @Post()
   @UseInterceptors(IdempotencyInterceptor)
@@ -454,5 +460,52 @@ export class PaymentsController {
   })
   cancel(@Param('id') id: string) {
     return this.paymentsService.cancel(id);
+  }
+
+  @Post(':id/settle')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Settle a payment on the Stellar network',
+    description:
+      'Submits a Stellar XLM payment for a COMPLETED facilpay payment. Idempotent — re-submitting a CONFIRMED settlement returns 409. A failed settlement can be retried.',
+  })
+  @ApiParam({ name: 'id', description: 'Payment UUID to settle' })
+  @ApiBody({ type: SettlePaymentDto })
+  @ApiOkResponse({
+    description: 'Settlement submitted and confirmed on Stellar.',
+    schema: {
+      example: {
+        id: 'abc123',
+        paymentId: '123e4567-e89b-12d3-a456-426614174000',
+        destinationAddress: 'GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3BHVJOVST',
+        xlmAmount: '10.5000000',
+        status: 'CONFIRMED',
+        transactionHash: 'abc123def456...',
+        ledger: 52345678,
+        createdAt: '2026-01-26T11:00:00.000Z',
+      },
+    },
+  })
+  @ApiNotFoundResponse({ description: 'Payment not found.' })
+  @ApiResponse({ status: 409, description: 'Already settled or in progress.' })
+  @ApiInternalServerErrorResponse({ description: 'Stellar transaction failed.' })
+  settle(@Param('id') id: string, @Body() dto: SettlePaymentDto) {
+    return this.settlementService.settle(id, dto);
+  }
+
+  @Get(':id/settlement')
+  @ApiOperation({
+    summary: 'Get Stellar settlement details for a payment',
+    description: 'Returns the Stellar settlement record for this payment, including transaction hash and status.',
+  })
+  @ApiParam({ name: 'id', description: 'Payment UUID' })
+  @ApiOkResponse({ description: 'Settlement record.' })
+  @ApiNotFoundResponse({ description: 'No settlement found for this payment.' })
+  async getSettlement(@Param('id') id: string) {
+    const settlement = await this.settlementService.getSettlement(id);
+    if (!settlement) {
+      throw new NotFoundException(`No settlement found for payment ${id}`);
+    }
+    return settlement;
   }
 }

--- a/src/modules/payments/payments.module.ts
+++ b/src/modules/payments/payments.module.ts
@@ -11,10 +11,16 @@ import { IdempotencyService } from './idempotency.service';
 import { IdempotencyInterceptor } from './idempotency.interceptor';
 import { CurrencyConfigService } from './currency-config.service';
 import { CurrenciesController } from './currencies.controller';
+import { SettlementService } from './settlement.service';
+import { StellarSettlement } from './entities/stellar-settlement.entity';
+import { StellarModule } from '../stellar/stellar.module';
 
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Payment, Refund, IdempotencyKey])],
+  imports: [
+    TypeOrmModule.forFeature([Payment, Refund, IdempotencyKey, StellarSettlement]),
+    StellarModule,
+  ],
   controllers: [PaymentsController, CurrenciesController],
 
   providers: [
@@ -24,7 +30,8 @@ import { CurrenciesController } from './currencies.controller';
     IdempotencyService,
     IdempotencyInterceptor,
     CurrencyConfigService,
+    SettlementService,
   ],
-  exports: [PaymentsService, WebhookSignatureService, WebhookGuard],
+  exports: [PaymentsService, WebhookSignatureService, WebhookGuard, SettlementService],
 })
 export class PaymentsModule { }

--- a/src/modules/payments/settlement.service.ts
+++ b/src/modules/payments/settlement.service.ts
@@ -1,0 +1,101 @@
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+  Logger,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Payment, PaymentStatus } from './payment.entity';
+import {
+  StellarSettlement,
+  SettlementStatus,
+} from './entities/stellar-settlement.entity';
+import { StellarService } from '../stellar/stellar.service';
+import { SettlePaymentDto } from './dto/settle-payment.dto';
+
+@Injectable()
+export class SettlementService {
+  private readonly logger = new Logger(SettlementService.name);
+
+  constructor(
+    @InjectRepository(Payment)
+    private readonly paymentRepository: Repository<Payment>,
+    @InjectRepository(StellarSettlement)
+    private readonly settlementRepository: Repository<StellarSettlement>,
+    private readonly stellarService: StellarService,
+  ) {}
+
+  async settle(
+    paymentId: string,
+    dto: SettlePaymentDto,
+  ): Promise<StellarSettlement> {
+    const payment = await this.paymentRepository.findOneBy({ id: paymentId });
+    if (!payment) {
+      throw new NotFoundException(`Payment ${paymentId} not found`);
+    }
+
+    if (payment.status !== PaymentStatus.COMPLETED) {
+      throw new ConflictException(
+        `Only COMPLETED payments can be settled on Stellar. Current status: ${payment.status}`,
+      );
+    }
+
+    const existing = await this.settlementRepository.findOneBy({ paymentId });
+    if (existing) {
+      if (existing.status === SettlementStatus.CONFIRMED) {
+        throw new ConflictException(
+          `Payment ${paymentId} is already settled (tx: ${existing.transactionHash})`,
+        );
+      }
+      if (existing.status === SettlementStatus.SUBMITTED) {
+        throw new ConflictException(
+          `Settlement for payment ${paymentId} is already in progress`,
+        );
+      }
+    }
+
+    const settlement =
+      existing ??
+      this.settlementRepository.create({
+        paymentId,
+        destinationAddress: dto.destinationAddress,
+        xlmAmount: dto.xlmAmount,
+        memo: dto.memo,
+        status: SettlementStatus.PENDING,
+      });
+
+    settlement.status = SettlementStatus.SUBMITTED;
+    await this.settlementRepository.save(settlement);
+
+    try {
+      const result = await this.stellarService.sendPayment(
+        dto.destinationAddress,
+        dto.xlmAmount,
+        dto.memo,
+      );
+
+      settlement.status = SettlementStatus.CONFIRMED;
+      settlement.transactionHash = result?.hash ?? null;
+      settlement.ledger = result?.ledger ?? null;
+      this.logger.log(
+        `Payment ${paymentId} settled on Stellar: ${result?.hash}`,
+      );
+    } catch (err) {
+      settlement.status = SettlementStatus.FAILED;
+      settlement.errorMessage =
+        err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Stellar settlement failed for payment ${paymentId}: ${settlement.errorMessage}`,
+      );
+      await this.settlementRepository.save(settlement);
+      throw err;
+    }
+
+    return this.settlementRepository.save(settlement);
+  }
+
+  async getSettlement(paymentId: string): Promise<StellarSettlement | null> {
+    return this.settlementRepository.findOneBy({ paymentId });
+  }
+}


### PR DESCRIPTION
## Summary

- `StellarSettlement` entity tracks Stellar transaction state per payment: `PENDING → SUBMITTED → CONFIRMED | FAILED`
- One-to-one relationship with Payment (unique constraint on `paymentId`)
- `SettlementService` validates: payment must be `COMPLETED`; prevents re-settling an already `CONFIRMED` settlement
- Failed settlements can be retried (no duplicate prevention for `FAILED` state)
- `POST /v1/payments/:id/settle` — initiates XLM transfer via `StellarService` which has circuit breaker + timeout protection (from #62)
- `GET /v1/payments/:id/settlement` — returns transaction hash, ledger number, and current status
- Migration `1706800000000-CreateStellarSettlementsTable`

## Test plan

- [ ] Create & complete a payment, then call `POST /v1/payments/:id/settle` with valid Stellar address
- [ ] Verify settlement status transitions to `CONFIRMED` with a `transactionHash`
- [ ] Attempt to settle a `PENDING` payment — verify `409 Conflict`
- [ ] Call settle twice on the same `CONFIRMED` payment — verify `409 Conflict`
- [ ] Call `GET /v1/payments/:id/settlement` — verify returns full settlement record
- [ ] Simulate Stellar failure (bad address) — verify status becomes `FAILED` and can be retried


🤖 Generated with [Claude Code](https://claude.com/claude-code)