### PR TITLE
feat(auth): implement refresh token rotation with reuse detection

### DIFF
--- a/src/migrations/1750400000000-AddIndexToRefreshTokens.ts
+++ b/src/migrations/1750400000000-AddIndexToRefreshTokens.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddIndexToRefreshTokens1750400000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_refresh_tokens_token" ON "refresh_tokens" ("token")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_refresh_tokens_token"`,
+    );
+  }
+}

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -335,19 +335,24 @@ export class AuthController {
   @Post('refresh')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
-    summary: 'Refresh access token',
+    summary: 'Refresh token pair',
     description:
-      'Issues a new JWT access token using a valid, non-expired, non-revoked refresh token.',
+      'Issues a new access token and a new refresh token. The presented refresh token is immediately invalidated (token rotation). ' +
+      'Reusing an already-invalidated refresh token returns 401 and revokes all active sessions for that user.',
   })
   @ApiBody({ type: RefreshTokenDto })
   @ApiOkResponse({
-    description: 'New access token issued.',
+    description: 'New token pair issued. Old refresh token is invalidated.',
     schema: {
-      example: { access_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' },
+      example: {
+        access_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+        refresh_token: '550e8400-e29b-41d4-a716-446655440000',
+      },
     },
   })
   @ApiUnauthorizedResponse({
-    description: 'Invalid, expired, or revoked refresh token.',
+    description:
+      'Invalid, expired, or already-used refresh token. If the token was previously rotated, all sessions for that user are revoked.',
     schema: {
       example: {
         statusCode: 401,

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -5,6 +5,7 @@ import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { UnauthorizedException } from '@nestjs/common';
 import { AppLogger } from '../logger/logger.service';
+import { DataSource } from 'typeorm';
 import * as bcrypt from 'bcrypt';
 
 jest.mock('bcrypt');
@@ -51,6 +52,16 @@ describe('AuthService', () => {
     }),
   };
 
+  const mockManager = {
+    findOne: jest.fn(),
+    update: jest.fn(),
+    getRepository: jest.fn(() => ({ save: jest.fn().mockResolvedValue({}) })),
+  };
+
+  const mockDataSource = {
+    transaction: jest.fn((cb) => cb(mockManager)),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -74,6 +85,10 @@ describe('AuthService', () => {
         {
           provide: require('./mail/mail.service').MailService,
           useValue: mockMailService,
+        },
+        {
+          provide: DataSource,
+          useValue: mockDataSource,
         },
         {
           provide: 'RefreshTokenRepository',
@@ -269,6 +284,98 @@ describe('AuthService', () => {
 
       expect(usersService.findOne).toHaveBeenCalledWith(userId);
       expect(result).toBeNull();
+    });
+  });
+
+  describe('refresh', () => {
+    const user = {
+      id: 'user-id-123',
+      email: 'test@example.com',
+      roles: ['USER'],
+    };
+
+    const validTokenRecord = {
+      id: 'token-row-id',
+      userId: user.id,
+      token: expect.any(String),
+      revoked: false,
+      expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    };
+
+    beforeEach(() => {
+      mockManager.findOne.mockReset();
+      mockManager.update.mockReset();
+      mockManager.getRepository.mockReset();
+      mockManager.getRepository.mockReturnValue({
+        save: jest.fn().mockResolvedValue({}),
+      });
+      mockJwtService.signAsync.mockResolvedValue('new-access-token');
+      mockUsersService.findOne.mockResolvedValue(user);
+    });
+
+    it('should rotate tokens on a valid refresh call', async () => {
+      mockManager.findOne.mockResolvedValue(validTokenRecord);
+      mockManager.update.mockResolvedValue(undefined);
+
+      const result = await service.refresh('raw-valid-token');
+
+      expect(result).toEqual({
+        access_token: 'new-access-token',
+        refresh_token: expect.any(String),
+      });
+
+      expect(mockManager.update).toHaveBeenCalledWith(
+        expect.anything(),
+        { id: validTokenRecord.id },
+        { revoked: true },
+      );
+    });
+
+    it('should return 401 for an expired refresh token', async () => {
+      mockManager.findOne.mockResolvedValue({
+        ...validTokenRecord,
+        expiresAt: new Date(Date.now() - 1000),
+      });
+
+      await expect(service.refresh('raw-expired-token')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should return 401 for a non-existent refresh token', async () => {
+      mockManager.findOne.mockResolvedValue(null);
+
+      await expect(service.refresh('raw-unknown-token')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should revoke all user sessions and return 401 on reuse of invalidated token', async () => {
+      const revokedTokenRecord = {
+        ...validTokenRecord,
+        revoked: true,
+      };
+      mockManager.findOne.mockResolvedValue(revokedTokenRecord);
+      mockManager.update.mockResolvedValue(undefined);
+
+      await expect(service.refresh('raw-reused-token')).rejects.toThrow(
+        UnauthorizedException,
+      );
+
+      expect(mockManager.update).toHaveBeenCalledWith(
+        expect.anything(),
+        { userId: user.id },
+        { revoked: true },
+      );
+    });
+
+    it('should return 401 when the user no longer exists', async () => {
+      mockManager.findOne.mockResolvedValue(validTokenRecord);
+      mockUsersService.findOne.mockRejectedValue(new Error('Not found'));
+
+      await expect(service.refresh('raw-valid-token')).rejects.toThrow(
+        UnauthorizedException,
+      );
     });
   });
 });

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -8,9 +8,8 @@ import {
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
-import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import {
   createCipheriv,
   createDecipheriv,
@@ -45,6 +44,7 @@ export class AuthService {
     private jwtService: JwtService,
     private mailService: MailService,
     private configService: ConfigService,
+    private dataSource: DataSource,
     @InjectRepository(RefreshToken)
     private refreshTokenRepository: Repository<RefreshToken>,
     @InjectRepository(PasswordResetToken)
@@ -259,30 +259,51 @@ export class AuthService {
     return { message: 'Email verified successfully. You can now log in.' };
   }
 
-  async refresh(rawToken: string): Promise<{ access_token: string }> {
+  async refresh(
+    rawToken: string,
+  ): Promise<{ access_token: string; refresh_token: string }> {
     const hashedToken = createHash('sha256').update(rawToken).digest('hex');
-    const tokenRecord = await this.refreshTokenRepository.findOne({
-      where: { token: hashedToken },
+
+    return this.dataSource.transaction(async (manager) => {
+      const tokenRecord = await manager.findOne(RefreshToken, {
+        where: { token: hashedToken },
+        lock: { mode: 'pessimistic_write' },
+      });
+
+      if (!tokenRecord || tokenRecord.expiresAt < new Date()) {
+        throw new UnauthorizedException('Invalid or expired refresh token');
+      }
+
+      if (tokenRecord.revoked) {
+        await manager.update(
+          RefreshToken,
+          { userId: tokenRecord.userId },
+          { revoked: true },
+        );
+        this.logger.warn(
+          { userId: tokenRecord.userId },
+          'Refresh token reuse detected — all sessions revoked',
+        );
+        throw new UnauthorizedException('Invalid or expired refresh token');
+      }
+
+      const user = await this.usersService
+        .findOne(tokenRecord.userId)
+        .catch(() => null);
+      if (!user) {
+        throw new UnauthorizedException('Invalid or expired refresh token');
+      }
+
+      await manager.update(RefreshToken, { id: tokenRecord.id }, { revoked: true });
+
+      const payload = { sub: user.id, email: user.email, roles: user.roles };
+      const [access_token, refresh_token] = await Promise.all([
+        this.jwtService.signAsync(payload),
+        this.generateRefreshToken(user.id, manager),
+      ]);
+
+      return { access_token, refresh_token };
     });
-
-    if (
-      !tokenRecord ||
-      tokenRecord.revoked ||
-      tokenRecord.expiresAt < new Date()
-    ) {
-      throw new UnauthorizedException('Invalid or expired refresh token');
-    }
-
-    const user = await this.usersService
-      .findOne(tokenRecord.userId)
-      .catch(() => null);
-    if (!user) {
-      throw new UnauthorizedException('Invalid or expired refresh token');
-    }
-
-    const payload = { sub: user.id, email: user.email };
-    const access_token = await this.jwtService.signAsync(payload);
-    return { access_token };
   }
 
   async logout(rawToken: string): Promise<void> {
@@ -303,19 +324,21 @@ export class AuthService {
     return this.sanitizeUser(user as User);
   }
 
-  private async generateRefreshToken(userId: string): Promise<string> {
+  private async generateRefreshToken(
+    userId: string,
+    manager?: EntityManager,
+  ): Promise<string> {
     const rawToken = randomUUID();
     const hashedToken = createHash('sha256').update(rawToken).digest('hex');
 
     const expiresAt = new Date();
     expiresAt.setDate(expiresAt.getDate() + 30);
 
-    await this.refreshTokenRepository.save({
-      token: hashedToken,
-      userId,
-      expiresAt,
-      revoked: false,
-    });
+    const repo = manager
+      ? manager.getRepository(RefreshToken)
+      : this.refreshTokenRepository;
+
+    await repo.save({ token: hashedToken, userId, expiresAt, revoked: false });
 
     return rawToken;
   }

--- a/src/modules/auth/entities/refresh-token.entity.ts
+++ b/src/modules/auth/entities/refresh-token.entity.ts
@@ -3,6 +3,7 @@ import {
   PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
+  Index,
 } from 'typeorm';
 
 @Entity('refresh_tokens')
@@ -10,6 +11,7 @@ export class RefreshToken {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
+  @Index('IDX_refresh_tokens_token')
   @Column({ unique: true })
   token: string;
 


### PR DESCRIPTION
## Summary

- **Token rotation**: `POST /auth/refresh` now invalidates the
  presented refresh token immediately and returns a new token pair
  `{ access_token, refresh_token }` instead of just an access token.
- **Reuse detection**: presenting an already-revoked refresh token
  returns 401 **and** revokes every active session for that user,
  forcing a re-login.
- **Concurrency safety**: the rotation runs inside a `DataSource`
  transaction with `SELECT FOR UPDATE`, so two simultaneous requests
  with the same token cannot both succeed — the second sees the
  now-revoked row and gets 401.
- **Index**: migration `1750400000000-AddIndexToRefreshTokens` adds a
  named index `IDX_refresh_tokens_token` for fast token lookup.
- **Swagger**: refresh endpoint description and response schema updated
  to document rotation and reuse-detection behaviour.

## Files changed

| File | Change |
|---|---|
| `src/modules/auth/entities/refresh-token.entity.ts` | `@Index` decorator on `token` column |
| `src/modules/auth/auth.service.ts` | `DataSource` injection, rewritten `refresh()`, updated `generateRefreshToken()` |
| `src/modules/auth/auth.controller.ts` | Swagger docs for `/auth/refresh` |
| `src/migrations/1750400000000-AddIndexToRefreshTokens.ts` | New migration |
| `src/modules/auth/auth.service.spec.ts` | `describe('refresh')` test suite (5 cases) |

closes #45 
## Test plan

- [ ] Run migration against a local DB: `npm run migration:run`
- [ ] `POST /auth/refresh` with a valid token → receives a new
  `access_token` **and** `refresh_token`; old token is rejected on
  reuse
- [ ] Repeat the call with the old refresh token → 401, all sessions
  revoked
- [ ] Run unit tests: `npm test -- auth.service.spec.ts`
- [ ] Verify Swagger UI at `/api` shows updated response schema for
  the refresh endpoint

