### PR TITLE
feat(payments): add webhook delivery entity, service, and migration

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,4 +10,7 @@ module.exports = {
   ],
   coverageDirectory: '../coverage',
   testEnvironment: 'node',
+  moduleNameMapper: {
+    '^lodash/(.*)$': '<rootDir>/../node_modules/lodash/$1',
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/axios": "^4.0.1",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
@@ -16,12 +17,14 @@
         "@nestjs/mapped-types": "^2.1.0",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/schedule": "^6.1.3",
         "@nestjs/swagger": "^11.2.5",
         "@nestjs/throttler": "^6.5.0",
         "@nestjs/typeorm": "^11.0.0",
         "@stellar/stellar-sdk": "^14.6.1",
         "@types/bcrypt": "^6.0.0",
         "@types/passport-jwt": "^4.0.1",
+        "axios": "^1.18.0",
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.3",
@@ -238,7 +241,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2100,6 +2102,17 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@nestjs/axios": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-4.0.1.tgz",
+      "integrity": "sha512-68pFJgu+/AZbWkGu65Z3r55bTsCPlgyKaV4BSG8yUAD72q1PPuyVRgUwFv6BxdnibTUHlyxm06FmYWNC+bjN7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "axios": "^1.3.1",
+        "rxjs": "^7.0.0"
+      }
+    },
     "node_modules/@nestjs/cli": {
       "version": "11.0.16",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-11.0.16.tgz",
@@ -2150,7 +2163,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.12.tgz",
       "integrity": "sha512-v6U3O01YohHO+IE3EIFXuRuu3VJILWzyMmSYZXpyBbnp0hk0mFyHxK2w3dF4I5WnbwiRbWlEXdeXFvPQ7qaZzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -2204,7 +2216,6 @@
       "integrity": "sha512-97DzTYMf5RtGAVvX1cjwpKRiCUpkeQ9CCzSAenqkAhOmNVVFaApbhuw+xrDt13rsCa2hHVOYPrV4dBgOYMJjsA==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2288,7 +2299,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.12.tgz",
       "integrity": "sha512-GYK/vHI0SGz5m8mxr7v3Urx8b9t78Cf/dj5aJMZlGd9/1D9OI1hAl00BaphjEXINUJ/BQLxIlF2zUjrYsd6enQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.2.1",
@@ -2303,6 +2313,19 @@
       "peerDependencies": {
         "@nestjs/common": "^11.0.0",
         "@nestjs/core": "^11.0.0"
+      }
+    },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.1.3.tgz",
+      "integrity": "sha512-RflMFOpR16Dwd1jAUbeB4mfGTCh65fvEdL4mSjQPJChpkRGRjIXjb+6YQcK2faQrVT60c9DmLmoVR7/ONCtuYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.4.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
       }
     },
     "node_modules/@nestjs/schematics": {
@@ -2843,7 +2866,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -2951,6 +2973,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-gW+Oib+vUtGJBtNC8V9Reww0oIpusw+4m81uncg9REGZAJfqOQHfo/nkabnc7w0QReXyPqjrbWMJk6NuAkiX3Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -2969,7 +2997,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
       "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3143,7 +3170,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -3825,7 +3851,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3869,13 +3894,24 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4098,13 +4134,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -4355,7 +4392,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4578,7 +4614,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -4626,15 +4661,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -4955,6 +4988,23 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.4.0.tgz",
+      "integrity": "sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.7.0",
+        "luxon": "~3.7.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/intcreator"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5310,7 +5360,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5371,7 +5420,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5613,7 +5661,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5844,9 +5891,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -6333,6 +6380,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -6716,7 +6776,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -7776,6 +7835,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -8399,7 +8467,6 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -8517,7 +8584,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.17.2.tgz",
       "integrity": "sha512-vjbKdiBJRqzcYw1fNU5KuHyYvdJ1qpcQg1CeBrHFqV1pWgHeVR6j/+kX0E1AAXfyuLUGY1ICrN2ELKA/z2HWzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.10.1",
         "pg-pool": "^3.11.0",
@@ -8824,7 +8890,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9043,8 +9108,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -9140,7 +9204,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -9835,7 +9898,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10195,7 +10257,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10356,7 +10417,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
       "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -10562,7 +10622,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10848,7 +10907,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -10918,7 +10976,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "docker:migrate": "docker compose run --rm api migrate"
   },
   "dependencies": {
+    "@nestjs/axios": "^4.0.1",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
@@ -34,12 +35,14 @@
     "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^11.2.5",
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.0",
     "@stellar/stellar-sdk": "^14.6.1",
     "@types/bcrypt": "^6.0.0",
     "@types/passport-jwt": "^4.0.1",
+    "axios": "^1.18.0",
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",

--- a/src/migrations/1750500000000-CreateWebhookDeliveriesTable.ts
+++ b/src/migrations/1750500000000-CreateWebhookDeliveriesTable.ts
@@ -1,0 +1,94 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+  TableIndex,
+} from 'typeorm';
+
+export class CreateWebhookDeliveriesTable1750500000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE payments
+      ADD COLUMN IF NOT EXISTS "callbackUrl" VARCHAR(2048)
+    `);
+
+    await queryRunner.query(`
+      CREATE TYPE webhook_delivery_status_enum
+      AS ENUM ('PENDING', 'DELIVERED', 'FAILED', 'DEAD')
+    `);
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'webhook_deliveries',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          { name: 'paymentId', type: 'uuid' },
+          { name: 'callbackUrl', type: 'varchar', length: '2048' },
+          { name: 'payload', type: 'jsonb' },
+          {
+            name: 'status',
+            type: 'enum',
+            enumName: 'webhook_delivery_status_enum',
+            default: "'PENDING'",
+          },
+          { name: 'attemptCount', type: 'int', default: '0' },
+          { name: 'lastAttemptAt', type: 'timestamp', isNullable: true },
+          { name: 'nextRetryAt', type: 'timestamp', isNullable: true },
+          { name: 'lastStatusCode', type: 'int', isNullable: true },
+          {
+            name: 'lastError',
+            type: 'varchar',
+            length: '500',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createForeignKey(
+      'webhook_deliveries',
+      new TableForeignKey({
+        columnNames: ['paymentId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'payments',
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'webhook_deliveries',
+      new TableIndex({
+        name: 'IDX_webhook_deliveries_status_nextRetryAt',
+        columnNames: ['status', 'nextRetryAt'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('webhook_deliveries');
+    await queryRunner.query(`DROP TYPE IF EXISTS webhook_delivery_status_enum`);
+    await queryRunner.query(
+      `ALTER TABLE payments DROP COLUMN IF EXISTS "callbackUrl"`,
+    );
+  }
+}

--- a/src/modules/payments/dto/create-payment.dto.ts
+++ b/src/modules/payments/dto/create-payment.dto.ts
@@ -3,13 +3,13 @@ import {
   IsString,
   IsNotEmpty,
   IsOptional,
+  IsUrl,
   Min,
   MaxLength,
   IsPositive,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsISO4217CurrencyCode } from '../../../common/validators/is-iso4217-currency-code.validator';
-
 
 export class CreatePaymentDto {
   @IsNumber()
@@ -33,7 +33,6 @@ export class CreatePaymentDto {
   @IsISO4217CurrencyCode({ supportedOnly: true })
   currency: string;
 
-
   @IsString()
   @IsOptional()
   @MaxLength(500, { message: 'Description must not exceed 500 characters' })
@@ -43,4 +42,13 @@ export class CreatePaymentDto {
     maxLength: 500,
   })
   description?: string;
+
+  @IsUrl({}, { message: 'callbackUrl must be a valid URL' })
+  @IsOptional()
+  @ApiPropertyOptional({
+    description: 'URL to receive outbound webhook notifications on payment status changes',
+    example: 'https://merchant.example.com/webhooks/payment',
+    maxLength: 2048,
+  })
+  callbackUrl?: string;
 }

--- a/src/modules/payments/dto/webhook-delivery-response.dto.ts
+++ b/src/modules/payments/dto/webhook-delivery-response.dto.ts
@@ -1,0 +1,43 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { WebhookDeliveryStatus } from '../webhook-delivery.entity';
+
+export class WebhookDeliveryResponseDto {
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174000' })
+  id: string;
+
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174001' })
+  paymentId: string;
+
+  @ApiProperty({ example: 'https://merchant.example.com/webhooks/payment' })
+  callbackUrl: string;
+
+  @ApiProperty({
+    description: 'Snapshot of the payment status payload sent in the webhook body',
+    example: { paymentId: '...', status: 'COMPLETED', amount: 100.5, currency: 'USD' },
+  })
+  payload: Record<string, unknown>;
+
+  @ApiProperty({ enum: WebhookDeliveryStatus, example: WebhookDeliveryStatus.DELIVERED })
+  status: WebhookDeliveryStatus;
+
+  @ApiProperty({ example: 1 })
+  attemptCount: number;
+
+  @ApiProperty({ nullable: true, example: '2026-06-20T10:05:00.000Z' })
+  lastAttemptAt: Date | null;
+
+  @ApiProperty({ nullable: true, example: '2026-06-20T10:06:00.000Z' })
+  nextRetryAt: Date | null;
+
+  @ApiProperty({ nullable: true, example: 200 })
+  lastStatusCode: number | null;
+
+  @ApiProperty({ nullable: true, example: 'connect ECONNREFUSED 127.0.0.1:3001' })
+  lastError: string | null;
+
+  @ApiProperty({ example: '2026-06-20T10:00:00.000Z' })
+  createdAt: Date;
+
+  @ApiProperty({ example: '2026-06-20T10:05:00.000Z' })
+  updatedAt: Date;
+}

--- a/src/modules/payments/payment.entity.ts
+++ b/src/modules/payments/payment.entity.ts
@@ -39,6 +39,9 @@ export class Payment {
   @Column({ nullable: true })
   description: string;
 
+  @Column({ nullable: true, length: 2048 })
+  callbackUrl: string | null;
+
   @Column({ type: 'decimal', precision: 10, scale: 2, default: 0 })
   refundedAmount: number;
 

--- a/src/modules/payments/webhook-delivery.entity.ts
+++ b/src/modules/payments/webhook-delivery.entity.ts
@@ -1,0 +1,64 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Payment } from './payment.entity';
+
+export enum WebhookDeliveryStatus {
+  PENDING = 'PENDING',
+  DELIVERED = 'DELIVERED',
+  FAILED = 'FAILED',
+  DEAD = 'DEAD',
+}
+
+@Entity('webhook_deliveries')
+export class WebhookDelivery {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  paymentId: string;
+
+  @ManyToOne(() => Payment)
+  @JoinColumn({ name: 'paymentId' })
+  payment: Payment;
+
+  @Column({ length: 2048 })
+  callbackUrl: string;
+
+  @Column({ type: 'jsonb' })
+  payload: Record<string, unknown>;
+
+  @Column({
+    type: 'enum',
+    enum: WebhookDeliveryStatus,
+    default: WebhookDeliveryStatus.PENDING,
+  })
+  status: WebhookDeliveryStatus;
+
+  @Column({ default: 0 })
+  attemptCount: number;
+
+  @Column({ nullable: true, type: 'timestamp' })
+  lastAttemptAt: Date | null;
+
+  @Column({ nullable: true, type: 'timestamp' })
+  nextRetryAt: Date | null;
+
+  @Column({ nullable: true, type: 'int' })
+  lastStatusCode: number | null;
+
+  @Column({ nullable: true, length: 500 })
+  lastError: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/payments/webhook-delivery.service.spec.ts
+++ b/src/modules/payments/webhook-delivery.service.spec.ts
@@ -1,0 +1,338 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { HttpService } from '@nestjs/axios';
+import { of, throwError } from 'rxjs';
+import {
+  WebhookDeliveryService,
+  BACKOFF_DELAYS_MS,
+  MAX_ATTEMPTS,
+} from './webhook-delivery.service';
+import { WebhookDelivery, WebhookDeliveryStatus } from './webhook-delivery.entity';
+import { AppLogger } from '../logger/logger.service';
+import { Payment, PaymentStatus } from './payment.entity';
+
+const mockRepo = () => ({
+  create: jest.fn(),
+  save: jest.fn(),
+  find: jest.fn(),
+});
+
+const mockHttpService = () => ({
+  post: jest.fn(),
+});
+
+const childLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+
+const mockAppLogger = {
+  child: jest.fn().mockReturnValue(childLogger),
+};
+
+describe('WebhookDeliveryService', () => {
+  let service: WebhookDeliveryService;
+  let repo: ReturnType<typeof mockRepo>;
+  let httpService: ReturnType<typeof mockHttpService>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhookDeliveryService,
+        { provide: getRepositoryToken(WebhookDelivery), useFactory: mockRepo },
+        { provide: HttpService, useFactory: mockHttpService },
+        { provide: AppLogger, useValue: mockAppLogger },
+      ],
+    }).compile();
+
+    service = module.get(WebhookDeliveryService);
+    repo = module.get(getRepositoryToken(WebhookDelivery));
+    httpService = module.get(HttpService);
+  });
+
+  describe('enqueue', () => {
+    it('creates a PENDING delivery row with attemptCount=0 and nextRetryAt=now', async () => {
+      const payment = {
+        id: 'pay-1',
+        callbackUrl: 'https://merchant.example.com/webhook',
+        status: PaymentStatus.COMPLETED,
+        amount: 100,
+        currency: 'USD',
+        externalReference: 'ext-1',
+        updatedAt: new Date(),
+      } as Payment;
+
+      const deliveryStub = { id: 'del-1' };
+      repo.create.mockReturnValue(deliveryStub);
+      repo.save.mockResolvedValue(deliveryStub);
+
+      await service.enqueue(payment);
+
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paymentId: 'pay-1',
+          callbackUrl: 'https://merchant.example.com/webhook',
+          status: WebhookDeliveryStatus.PENDING,
+          attemptCount: 0,
+        }),
+      );
+      expect(repo.save).toHaveBeenCalledWith(deliveryStub);
+    });
+
+    it('does nothing when payment has no callbackUrl', async () => {
+      const payment = { id: 'pay-1', callbackUrl: null } as Payment;
+      await service.enqueue(payment);
+      expect(repo.create).not.toHaveBeenCalled();
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    it('stores a payload snapshot with paymentId, status, amount, currency', async () => {
+      const payment = {
+        id: 'pay-1',
+        callbackUrl: 'https://example.com/hook',
+        status: PaymentStatus.COMPLETED,
+        amount: 50.0,
+        currency: 'NGN',
+        externalReference: 'ref-x',
+        updatedAt: new Date('2026-06-20T10:00:00Z'),
+      } as Payment;
+
+      repo.create.mockReturnValue({});
+      repo.save.mockResolvedValue({});
+
+      await service.enqueue(payment);
+
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            paymentId: 'pay-1',
+            status: PaymentStatus.COMPLETED,
+            amount: 50.0,
+            currency: 'NGN',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('attempt', () => {
+    it('marks delivery DELIVERED and records status code on 2xx response', async () => {
+      const delivery = {
+        id: 'del-1',
+        paymentId: 'pay-1',
+        callbackUrl: 'https://merchant.example.com/webhook',
+        payload: { paymentId: 'pay-1', status: 'COMPLETED' },
+        attemptCount: 0,
+        status: WebhookDeliveryStatus.PENDING,
+      } as WebhookDelivery;
+
+      httpService.post.mockReturnValue(of({ status: 200, data: {} }));
+      repo.save.mockResolvedValue(delivery);
+
+      await service.attempt(delivery);
+
+      expect(delivery.status).toBe(WebhookDeliveryStatus.DELIVERED);
+      expect(delivery.attemptCount).toBe(1);
+      expect(delivery.lastStatusCode).toBe(200);
+      expect(delivery.nextRetryAt).toBeNull();
+      expect(repo.save).toHaveBeenCalledWith(delivery);
+    });
+
+    it('marks delivery FAILED and sets nextRetryAt after first failure', async () => {
+      const delivery = {
+        id: 'del-1',
+        paymentId: 'pay-1',
+        callbackUrl: 'https://merchant.example.com/webhook',
+        payload: {},
+        attemptCount: 0,
+        status: WebhookDeliveryStatus.PENDING,
+      } as WebhookDelivery;
+
+      httpService.post.mockReturnValue(
+        throwError(() => ({ response: { status: 500 }, message: 'Server error' })),
+      );
+      repo.save.mockResolvedValue(delivery);
+
+      const before = Date.now();
+      await service.attempt(delivery);
+
+      expect(delivery.status).toBe(WebhookDeliveryStatus.FAILED);
+      expect(delivery.attemptCount).toBe(1);
+      expect(delivery.lastStatusCode).toBe(500);
+      expect(delivery.nextRetryAt).not.toBeNull();
+      expect(delivery.nextRetryAt!.getTime()).toBeGreaterThanOrEqual(
+        before + BACKOFF_DELAYS_MS[0],
+      );
+    });
+
+    it('marks delivery DEAD after MAX_ATTEMPTS failures', async () => {
+      const delivery = {
+        id: 'del-1',
+        paymentId: 'pay-1',
+        callbackUrl: 'https://merchant.example.com/webhook',
+        payload: {},
+        attemptCount: MAX_ATTEMPTS - 1,
+        status: WebhookDeliveryStatus.FAILED,
+      } as WebhookDelivery;
+
+      httpService.post.mockReturnValue(
+        throwError(() => new Error('Network error')),
+      );
+      repo.save.mockResolvedValue(delivery);
+
+      await service.attempt(delivery);
+
+      expect(delivery.status).toBe(WebhookDeliveryStatus.DEAD);
+      expect(delivery.attemptCount).toBe(MAX_ATTEMPTS);
+      expect(delivery.nextRetryAt).toBeNull();
+    });
+
+    it.each([
+      [0, 60_000],
+      [1, 300_000],
+      [2, 1_800_000],
+      [3, 7_200_000],
+    ])(
+      'sets nextRetryAt to +%i ms after attempt %i fails',
+      async (attemptCount, expectedDelayMs) => {
+        const delivery = {
+          id: `del-${attemptCount}`,
+          paymentId: 'pay-1',
+          callbackUrl: 'https://example.com',
+          payload: {},
+          attemptCount,
+          status: WebhookDeliveryStatus.PENDING,
+        } as WebhookDelivery;
+
+        httpService.post.mockReturnValue(throwError(() => new Error('fail')));
+        repo.save.mockResolvedValue(delivery);
+
+        const before = Date.now();
+        await service.attempt(delivery);
+
+        expect(delivery.nextRetryAt!.getTime()).toBeGreaterThanOrEqual(
+          before + expectedDelayMs,
+        );
+        expect(delivery.nextRetryAt!.getTime()).toBeLessThan(
+          before + expectedDelayMs + 500,
+        );
+      },
+    );
+
+    it('records lastError from network failure', async () => {
+      const delivery = {
+        id: 'del-1',
+        paymentId: 'pay-1',
+        callbackUrl: 'https://merchant.example.com/webhook',
+        payload: {},
+        attemptCount: 0,
+        status: WebhookDeliveryStatus.PENDING,
+      } as WebhookDelivery;
+
+      httpService.post.mockReturnValue(
+        throwError(() => new Error('connect ECONNREFUSED 127.0.0.1:3001')),
+      );
+      repo.save.mockResolvedValue(delivery);
+
+      await service.attempt(delivery);
+
+      expect(delivery.lastError).toBe('connect ECONNREFUSED 127.0.0.1:3001');
+    });
+
+    it('emits a structured log event on success', async () => {
+      const delivery = {
+        id: 'del-1',
+        paymentId: 'pay-1',
+        callbackUrl: 'https://example.com',
+        payload: {},
+        attemptCount: 0,
+        status: WebhookDeliveryStatus.PENDING,
+      } as WebhookDelivery;
+
+      httpService.post.mockReturnValue(of({ status: 201, data: {} }));
+      repo.save.mockResolvedValue(delivery);
+
+      await service.attempt(delivery);
+
+      expect(childLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'webhook_delivery_succeeded' }),
+        expect.any(String),
+      );
+    });
+
+    it('emits a structured log event on failure', async () => {
+      const delivery = {
+        id: 'del-1',
+        paymentId: 'pay-1',
+        callbackUrl: 'https://example.com',
+        payload: {},
+        attemptCount: 0,
+        status: WebhookDeliveryStatus.PENDING,
+      } as WebhookDelivery;
+
+      httpService.post.mockReturnValue(throwError(() => new Error('fail')));
+      repo.save.mockResolvedValue(delivery);
+
+      await service.attempt(delivery);
+
+      expect(childLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'webhook_delivery_failed' }),
+        expect.any(String),
+      );
+    });
+
+    it('emits a structured log event when delivery is marked DEAD', async () => {
+      const delivery = {
+        id: 'del-1',
+        paymentId: 'pay-1',
+        callbackUrl: 'https://example.com',
+        payload: {},
+        attemptCount: MAX_ATTEMPTS - 1,
+        status: WebhookDeliveryStatus.FAILED,
+      } as WebhookDelivery;
+
+      httpService.post.mockReturnValue(throwError(() => new Error('fail')));
+      repo.save.mockResolvedValue(delivery);
+
+      await service.attempt(delivery);
+
+      expect(childLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'webhook_delivery_dead' }),
+        expect.any(String),
+      );
+    });
+  });
+
+  describe('findDue', () => {
+    it('queries for PENDING and FAILED deliveries with nextRetryAt <= now', async () => {
+      repo.find.mockResolvedValue([]);
+      await service.findDue();
+      expect(repo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.arrayContaining([
+            expect.objectContaining({ status: WebhookDeliveryStatus.PENDING }),
+            expect.objectContaining({ status: WebhookDeliveryStatus.FAILED }),
+          ]),
+        }),
+      );
+    });
+  });
+
+  describe('findByPaymentId', () => {
+    it('returns deliveries for the given paymentId ordered by createdAt DESC', async () => {
+      const deliveries = [{ id: 'del-1' }, { id: 'del-2' }] as WebhookDelivery[];
+      repo.find.mockResolvedValue(deliveries);
+
+      const result = await service.findByPaymentId('pay-1');
+
+      expect(repo.find).toHaveBeenCalledWith({
+        where: { paymentId: 'pay-1' },
+        order: { createdAt: 'DESC' },
+      });
+      expect(result).toBe(deliveries);
+    });
+  });
+});

--- a/src/modules/payments/webhook-delivery.service.ts
+++ b/src/modules/payments/webhook-delivery.service.ts
@@ -1,0 +1,143 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThanOrEqual } from 'typeorm';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
+import { WebhookDelivery, WebhookDeliveryStatus } from './webhook-delivery.entity';
+import { Payment } from './payment.entity';
+import { AppLogger } from '../logger/logger.service';
+import { Logger } from 'pino';
+
+export const MAX_ATTEMPTS = 5;
+export const BACKOFF_DELAYS_MS = [
+  60_000,        // after attempt 1 → retry in 1 min
+  300_000,       // after attempt 2 → retry in 5 min
+  1_800_000,     // after attempt 3 → retry in 30 min
+  7_200_000,     // after attempt 4 → retry in 2 h
+];
+
+@Injectable()
+export class WebhookDeliveryService {
+  private readonly logger: Logger;
+
+  constructor(
+    @InjectRepository(WebhookDelivery)
+    private readonly deliveryRepo: Repository<WebhookDelivery>,
+    private readonly httpService: HttpService,
+    appLogger: AppLogger,
+  ) {
+    this.logger = appLogger.child({ module: WebhookDeliveryService.name });
+  }
+
+  async enqueue(payment: Payment): Promise<void> {
+    if (!payment.callbackUrl) return;
+
+    const delivery = this.deliveryRepo.create({
+      paymentId: payment.id,
+      callbackUrl: payment.callbackUrl,
+      payload: {
+        paymentId: payment.id,
+        status: payment.status,
+        amount: payment.amount,
+        currency: payment.currency,
+        externalReference: payment.externalReference,
+        updatedAt: payment.updatedAt,
+      },
+      status: WebhookDeliveryStatus.PENDING,
+      attemptCount: 0,
+      nextRetryAt: new Date(),
+    });
+
+    await this.deliveryRepo.save(delivery);
+    this.logger.info(
+      { paymentId: payment.id, deliveryId: delivery.id, event: 'webhook_delivery_enqueued' },
+      'Webhook delivery enqueued',
+    );
+  }
+
+  async attempt(delivery: WebhookDelivery): Promise<void> {
+    const now = new Date();
+    delivery.lastAttemptAt = now;
+    delivery.attemptCount += 1;
+
+    try {
+      const response = await firstValueFrom(
+        this.httpService.post(delivery.callbackUrl, delivery.payload, {
+          timeout: 10_000,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+      delivery.status = WebhookDeliveryStatus.DELIVERED;
+      delivery.lastStatusCode = response.status;
+      delivery.nextRetryAt = null;
+
+      this.logger.info(
+        {
+          deliveryId: delivery.id,
+          paymentId: delivery.paymentId,
+          attempt: delivery.attemptCount,
+          statusCode: response.status,
+          event: 'webhook_delivery_succeeded',
+        },
+        'Webhook delivered successfully',
+      );
+    } catch (error: unknown) {
+      const axiosError = error as { response?: { status?: number }; message?: string };
+      const statusCode = axiosError?.response?.status ?? null;
+      const errorMsg = axiosError instanceof Error ? axiosError.message : String(axiosError);
+
+      delivery.lastStatusCode = statusCode ?? null;
+      delivery.lastError = errorMsg.slice(0, 500);
+
+      if (delivery.attemptCount >= MAX_ATTEMPTS) {
+        delivery.status = WebhookDeliveryStatus.DEAD;
+        delivery.nextRetryAt = null;
+
+        this.logger.warn(
+          {
+            deliveryId: delivery.id,
+            paymentId: delivery.paymentId,
+            attempt: delivery.attemptCount,
+            event: 'webhook_delivery_dead',
+          },
+          'Webhook delivery permanently failed',
+        );
+      } else {
+        delivery.status = WebhookDeliveryStatus.FAILED;
+        const delayMs = BACKOFF_DELAYS_MS[delivery.attemptCount - 1];
+        delivery.nextRetryAt = new Date(now.getTime() + delayMs);
+
+        this.logger.warn(
+          {
+            deliveryId: delivery.id,
+            paymentId: delivery.paymentId,
+            attempt: delivery.attemptCount,
+            nextRetryAt: delivery.nextRetryAt,
+            event: 'webhook_delivery_failed',
+          },
+          'Webhook delivery failed, will retry',
+        );
+      }
+    }
+
+    await this.deliveryRepo.save(delivery);
+  }
+
+  async findDue(): Promise<WebhookDelivery[]> {
+    const now = new Date();
+    return this.deliveryRepo.find({
+      where: [
+        { status: WebhookDeliveryStatus.PENDING, nextRetryAt: LessThanOrEqual(now) },
+        { status: WebhookDeliveryStatus.FAILED, nextRetryAt: LessThanOrEqual(now) },
+      ],
+    });
+  }
+
+  async findByPaymentId(paymentId: string): Promise<WebhookDelivery[]> {
+    return this.deliveryRepo.find({
+      where: { paymentId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Implements durable outbound webhook delivery with exponential backoff retry so downstream systems never permanently miss payment status updates.

- `callbackUrl` added to `Payment` entity and `CreatePaymentDto` (optional field; payments without it are unaffected)
- New `webhook_deliveries` table tracks each outbound delivery attempt: URL, JSON payload snapshot, status (PENDING → DELIVERED/FAILED → DEAD), attempt count, next retry time, HTTP status code, and error message
- `WebhookDeliveryService` handles enqueueing and delivery attempts. Failed attempts back off at 1 min → 5 min → 30 min → 2 h; after 5 failures the row is marked DEAD
- Structured Pino log events emitted for every outcome (`webhook_delivery_enqueued`, `webhook_delivery_succeeded`, `webhook_delivery_failed`, `webhook_delivery_dead`)
closes #48 
**Still pending in follow-up:** `WebhookRetryScheduler` (`@Cron` job), `PaymentsService.handleWebhook` integration, and `GET /v1/payments/:id/webhook-deliveries` admin endpoint.

## Test plan
- [ ] `npm test -- --testPathPattern=webhook-delivery.service.spec` → 16 tests pass
- [ ] `npm test` → no regressions in existing suites

