### PR TITLE
feat: add payment analytics endpoints

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,5 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { DatabaseModule } from './modules/database/database.module';
 import { HealthModule } from './modules/health/health.module';
 import { AuthModule } from './modules/auth/auth.module';
@@ -17,6 +17,7 @@ import { StellarModule } from './modules/stellar/stellar.module';
 import { BullModule } from '@nestjs/bullmq';
 import { CorsModule } from './modules/cors/cors.module';
 import { ApiKeysModule } from './modules/api-keys/api-keys.module';
+import { AnalyticsModule } from './modules/analytics/analytics.module';
 
 @Module({
   imports: [
@@ -43,6 +44,7 @@ import { ApiKeysModule } from './modules/api-keys/api-keys.module';
     WebhooksModule,
     StellarModule,
     ApiKeysModule,
+    AnalyticsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/migrations/1752000000000-AddUserIdToPayments.ts
+++ b/src/migrations/1752000000000-AddUserIdToPayments.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUserIdToPayments1752000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "payments" ADD COLUMN IF NOT EXISTS "userId" uuid NULL`,
+    );
+
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_payments_user_id" ON "payments" ("userId")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "idx_payments_user_id"`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE "payments" DROP COLUMN IF EXISTS "userId"`,
+    );
+  }
+}

--- a/src/modules/analytics/analytics-cache.service.ts
+++ b/src/modules/analytics/analytics-cache.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+import { AppLogger } from '../logger/logger.service';
+import { Logger } from 'pino';
+
+@Injectable()
+export class AnalyticsCacheService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger: Logger;
+  private client: Redis;
+
+  constructor(
+    private readonly configService: ConfigService,
+    appLogger: AppLogger,
+  ) {
+    this.logger = appLogger.child({ module: AnalyticsCacheService.name });
+  }
+
+  onModuleInit(): void {
+    const host = this.configService.get<string>('REDIS_HOST', 'localhost');
+    const port = this.configService.get<number>('REDIS_PORT', 6379);
+
+    this.client = new Redis({ host, port, lazyConnect: true });
+
+    this.client.on('error', (err: Error) => {
+      this.logger.error({ err }, 'Redis connection error in analytics cache');
+    });
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.client) {
+      await this.client.quit();
+    }
+  }
+
+  /**
+   * Retrieve a cached value. Returns null on cache miss or Redis error.
+   */
+  async get<T>(key: string): Promise<T | null> {
+    try {
+      const raw = await this.client.get(key);
+      if (!raw) return null;
+      return JSON.parse(raw) as T;
+    } catch (err) {
+      this.logger.warn({ err, key }, 'Cache GET failed, treating as miss');
+      return null;
+    }
+  }
+
+  /**
+   * Store a value in cache with a TTL in seconds. Silently ignores Redis errors.
+   */
+  async set(key: string, value: unknown, ttlSeconds = 60): Promise<void> {
+    try {
+      await this.client.set(key, JSON.stringify(value), 'EX', ttlSeconds);
+    } catch (err) {
+      this.logger.warn({ err, key }, 'Cache SET failed, skipping cache write');
+    }
+  }
+}

--- a/src/modules/analytics/analytics.controller.ts
+++ b/src/modules/analytics/analytics.controller.ts
@@ -1,0 +1,111 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiOkResponse,
+  ApiUnauthorizedResponse,
+  ApiBearerAuth,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { User } from '../users/user.entity';
+import { AnalyticsService } from './analytics.service';
+import { AnalyticsQueryDto, AnalyticsPeriod } from './dto/analytics-query.dto';
+import {
+  PaymentMetricsDto,
+  CurrencyBreakdownDto,
+  StatusBreakdownDto,
+} from './dto/analytics-response.dto';
+
+@ApiTags('analytics')
+@ApiBearerAuth('bearer')
+@UseGuards(JwtAuthGuard)
+@Controller('v1/analytics')
+export class AnalyticsController {
+  constructor(private readonly analyticsService: AnalyticsService) {}
+
+  @Get('payments')
+  @ApiOperation({
+    summary: 'Get payment metrics',
+    description:
+      'Returns aggregated payment metrics (total volume, count, and average amount) for the authenticated merchant over the requested time period.',
+  })
+  @ApiQuery({
+    name: 'period',
+    enum: AnalyticsPeriod,
+    required: false,
+    description: 'Time period for aggregation. Defaults to month.',
+    example: 'month',
+  })
+  @ApiOkResponse({
+    description: 'Payment metrics successfully retrieved.',
+    type: PaymentMetricsDto,
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
+  async getPaymentMetrics(
+    @Query() query: AnalyticsQueryDto,
+    @CurrentUser() user: User,
+  ): Promise<PaymentMetricsDto> {
+    return this.analyticsService.getPaymentMetrics(
+      user.id,
+      query.period ?? AnalyticsPeriod.MONTH,
+    );
+  }
+
+  @Get('payments/by-currency')
+  @ApiOperation({
+    summary: 'Get payments breakdown by currency',
+    description:
+      'Returns payment volume, count, and average amount grouped by currency for the authenticated merchant over the requested time period.',
+  })
+  @ApiQuery({
+    name: 'period',
+    enum: AnalyticsPeriod,
+    required: false,
+    description: 'Time period for aggregation. Defaults to month.',
+    example: 'month',
+  })
+  @ApiOkResponse({
+    description: 'Currency breakdown successfully retrieved.',
+    type: CurrencyBreakdownDto,
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
+  async getPaymentsByCurrency(
+    @Query() query: AnalyticsQueryDto,
+    @CurrentUser() user: User,
+  ): Promise<CurrencyBreakdownDto> {
+    return this.analyticsService.getPaymentsByCurrency(
+      user.id,
+      query.period ?? AnalyticsPeriod.MONTH,
+    );
+  }
+
+  @Get('payments/by-status')
+  @ApiOperation({
+    summary: 'Get payments breakdown by status',
+    description:
+      'Returns payment count and volume grouped by status, plus overall success and failure rates, for the authenticated merchant over the requested time period.',
+  })
+  @ApiQuery({
+    name: 'period',
+    enum: AnalyticsPeriod,
+    required: false,
+    description: 'Time period for aggregation. Defaults to month.',
+    example: 'month',
+  })
+  @ApiOkResponse({
+    description: 'Status breakdown successfully retrieved.',
+    type: StatusBreakdownDto,
+  })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT token.' })
+  async getPaymentsByStatus(
+    @Query() query: AnalyticsQueryDto,
+    @CurrentUser() user: User,
+  ): Promise<StatusBreakdownDto> {
+    return this.analyticsService.getPaymentsByStatus(
+      user.id,
+      query.period ?? AnalyticsPeriod.MONTH,
+    );
+  }
+}

--- a/src/modules/analytics/analytics.module.ts
+++ b/src/modules/analytics/analytics.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import { Payment } from '../payments/payment.entity';
+import { AnalyticsController } from './analytics.controller';
+import { AnalyticsService } from './analytics.service';
+import { AnalyticsCacheService } from './analytics-cache.service';
+
+@Module({
+  imports: [
+    ConfigModule,
+    TypeOrmModule.forFeature([Payment]),
+  ],
+  controllers: [AnalyticsController],
+  providers: [AnalyticsService, AnalyticsCacheService],
+})
+export class AnalyticsModule {}

--- a/src/modules/analytics/analytics.service.ts
+++ b/src/modules/analytics/analytics.service.ts
@@ -1,0 +1,239 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Payment, PaymentStatus } from '../payments/payment.entity';
+import { AppLogger } from '../logger/logger.service';
+import { Logger } from 'pino';
+import { AnalyticsCacheService } from './analytics-cache.service';
+import { AnalyticsPeriod } from './dto/analytics-query.dto';
+import {
+  PaymentMetricsDto,
+  CurrencyBreakdownDto,
+  StatusBreakdownDto,
+  StatusBreakdownItemDto,
+} from './dto/analytics-response.dto';
+
+const CACHE_TTL_SECONDS = 60;
+
+@Injectable()
+export class AnalyticsService {
+  private readonly logger: Logger;
+
+  constructor(
+    @InjectRepository(Payment)
+    private readonly paymentRepository: Repository<Payment>,
+    private readonly cacheService: AnalyticsCacheService,
+    appLogger: AppLogger,
+  ) {
+    this.logger = appLogger.child({ module: AnalyticsService.name });
+  }
+
+  /**
+   * Compute the [start, end] date range for the requested period relative to now.
+   */
+  private getPeriodRange(period: AnalyticsPeriod): { start: Date; end: Date } {
+    const now = new Date();
+    const end = new Date(now);
+    let start: Date;
+
+    switch (period) {
+      case AnalyticsPeriod.DAY:
+        start = new Date(now);
+        start.setUTCHours(0, 0, 0, 0);
+        end.setUTCHours(23, 59, 59, 999);
+        break;
+      case AnalyticsPeriod.WEEK: {
+        start = new Date(now);
+        const day = start.getUTCDay(); // 0 = Sunday
+        start.setUTCDate(start.getUTCDate() - day);
+        start.setUTCHours(0, 0, 0, 0);
+        end.setUTCHours(23, 59, 59, 999);
+        break;
+      }
+      case AnalyticsPeriod.MONTH:
+        start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+        end.setUTCHours(23, 59, 59, 999);
+        break;
+      case AnalyticsPeriod.YEAR:
+        start = new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
+        end.setUTCHours(23, 59, 59, 999);
+        break;
+      default:
+        start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+        end.setUTCHours(23, 59, 59, 999);
+    }
+
+    return { start, end };
+  }
+
+  /**
+   * GET /v1/analytics/payments
+   * Total volume, count, and average amount for the requesting merchant.
+   */
+  async getPaymentMetrics(
+    userId: string,
+    period: AnalyticsPeriod,
+  ): Promise<PaymentMetricsDto> {
+    const cacheKey = `analytics:metrics:${userId}:${period}`;
+    const cached = await this.cacheService.get<PaymentMetricsDto>(cacheKey);
+    if (cached) {
+      this.logger.debug({ cacheKey }, 'Analytics metrics cache hit');
+      return cached;
+    }
+
+    const { start, end } = this.getPeriodRange(period);
+
+    const result = await this.paymentRepository
+      .createQueryBuilder('payment')
+      .select('COALESCE(SUM(payment.amount::numeric), 0)', 'totalVolume')
+      .addSelect('COUNT(payment.id)', 'totalCount')
+      .addSelect('COALESCE(AVG(payment.amount::numeric), 0)', 'averageAmount')
+      .where('payment.userId = :userId', { userId })
+      .andWhere('payment.createdAt >= :start', { start })
+      .andWhere('payment.createdAt <= :end', { end })
+      .getRawOne<{ totalVolume: string; totalCount: string; averageAmount: string }>();
+
+    const metrics: PaymentMetricsDto = {
+      totalVolume: parseFloat(result?.totalVolume ?? '0'),
+      totalCount: parseInt(result?.totalCount ?? '0', 10),
+      averageAmount: parseFloat(result?.averageAmount ?? '0'),
+      period,
+      periodStart: start.toISOString(),
+      periodEnd: end.toISOString(),
+    };
+
+    await this.cacheService.set(cacheKey, metrics, CACHE_TTL_SECONDS);
+    this.logger.debug({ userId, period }, 'Analytics metrics computed and cached');
+
+    return metrics;
+  }
+
+  /**
+   * GET /v1/analytics/payments/by-currency
+   * Payment volume and count grouped by currency for the requesting merchant.
+   */
+  async getPaymentsByCurrency(
+    userId: string,
+    period: AnalyticsPeriod,
+  ): Promise<CurrencyBreakdownDto> {
+    const cacheKey = `analytics:by-currency:${userId}:${period}`;
+    const cached = await this.cacheService.get<CurrencyBreakdownDto>(cacheKey);
+    if (cached) {
+      this.logger.debug({ cacheKey }, 'Analytics by-currency cache hit');
+      return cached;
+    }
+
+    const { start, end } = this.getPeriodRange(period);
+
+    const rows = await this.paymentRepository
+      .createQueryBuilder('payment')
+      .select('payment.currency', 'currency')
+      .addSelect('COALESCE(SUM(payment.amount::numeric), 0)', 'totalVolume')
+      .addSelect('COUNT(payment.id)', 'count')
+      .addSelect('COALESCE(AVG(payment.amount::numeric), 0)', 'averageAmount')
+      .where('payment.userId = :userId', { userId })
+      .andWhere('payment.createdAt >= :start', { start })
+      .andWhere('payment.createdAt <= :end', { end })
+      .groupBy('payment.currency')
+      .orderBy('"totalVolume"', 'DESC')
+      .getRawMany<{
+        currency: string;
+        totalVolume: string;
+        count: string;
+        averageAmount: string;
+      }>();
+
+    const result: CurrencyBreakdownDto = {
+      breakdown: rows.map((row) => ({
+        currency: row.currency,
+        totalVolume: parseFloat(row.totalVolume),
+        count: parseInt(row.count, 10),
+        averageAmount: parseFloat(row.averageAmount),
+      })),
+      period,
+      periodStart: start.toISOString(),
+      periodEnd: end.toISOString(),
+    };
+
+    await this.cacheService.set(cacheKey, result, CACHE_TTL_SECONDS);
+    this.logger.debug({ userId, period }, 'Analytics by-currency computed and cached');
+
+    return result;
+  }
+
+  /**
+   * GET /v1/analytics/payments/by-status
+   * Payment breakdown by status with success/failure rates for the requesting merchant.
+   */
+  async getPaymentsByStatus(
+    userId: string,
+    period: AnalyticsPeriod,
+  ): Promise<StatusBreakdownDto> {
+    const cacheKey = `analytics:by-status:${userId}:${period}`;
+    const cached = await this.cacheService.get<StatusBreakdownDto>(cacheKey);
+    if (cached) {
+      this.logger.debug({ cacheKey }, 'Analytics by-status cache hit');
+      return cached;
+    }
+
+    const { start, end } = this.getPeriodRange(period);
+
+    const rows = await this.paymentRepository
+      .createQueryBuilder('payment')
+      .select('payment.status', 'status')
+      .addSelect('COUNT(payment.id)', 'count')
+      .addSelect('COALESCE(SUM(payment.amount::numeric), 0)', 'totalVolume')
+      .where('payment.userId = :userId', { userId })
+      .andWhere('payment.createdAt >= :start', { start })
+      .andWhere('payment.createdAt <= :end', { end })
+      .groupBy('payment.status')
+      .getRawMany<{ status: string; count: string; totalVolume: string }>();
+
+    const totalCount = rows.reduce((sum, r) => sum + parseInt(r.count, 10), 0);
+
+    const breakdown: StatusBreakdownItemDto[] = rows.map((row) => {
+      const count = parseInt(row.count, 10);
+      return {
+        status: row.status,
+        count,
+        percentage:
+          totalCount > 0
+            ? parseFloat(((count / totalCount) * 100).toFixed(2))
+            : 0,
+        totalVolume: parseFloat(row.totalVolume),
+      };
+    });
+
+    // Sort by count descending for readability
+    breakdown.sort((a, b) => b.count - a.count);
+
+    const completedRow = rows.find((r) => r.status === PaymentStatus.COMPLETED);
+    const failedRow = rows.find((r) => r.status === PaymentStatus.FAILED);
+
+    const completedCount = completedRow ? parseInt(completedRow.count, 10) : 0;
+    const failedCount = failedRow ? parseInt(failedRow.count, 10) : 0;
+
+    const successRate =
+      totalCount > 0
+        ? parseFloat(((completedCount / totalCount) * 100).toFixed(2))
+        : 0;
+    const failureRate =
+      totalCount > 0
+        ? parseFloat(((failedCount / totalCount) * 100).toFixed(2))
+        : 0;
+
+    const result: StatusBreakdownDto = {
+      breakdown,
+      successRate,
+      failureRate,
+      period,
+      periodStart: start.toISOString(),
+      periodEnd: end.toISOString(),
+    };
+
+    await this.cacheService.set(cacheKey, result, CACHE_TTL_SECONDS);
+    this.logger.debug({ userId, period }, 'Analytics by-status computed and cached');
+
+    return result;
+  }
+}

--- a/src/modules/analytics/dto/analytics-query.dto.ts
+++ b/src/modules/analytics/dto/analytics-query.dto.ts
@@ -1,0 +1,23 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+
+export enum AnalyticsPeriod {
+  DAY = 'day',
+  WEEK = 'week',
+  MONTH = 'month',
+  YEAR = 'year',
+}
+
+export class AnalyticsQueryDto {
+  @ApiPropertyOptional({
+    enum: AnalyticsPeriod,
+    description: 'Time period for aggregation',
+    default: AnalyticsPeriod.MONTH,
+    example: 'month',
+  })
+  @IsEnum(AnalyticsPeriod, {
+    message: 'period must be one of: day, week, month, year',
+  })
+  @IsOptional()
+  period?: AnalyticsPeriod = AnalyticsPeriod.MONTH;
+}

--- a/src/modules/analytics/dto/analytics-response.dto.ts
+++ b/src/modules/analytics/dto/analytics-response.dto.ts
@@ -1,0 +1,154 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PaymentMetricsDto {
+  @ApiProperty({
+    description: 'Total payment volume (sum of amounts)',
+    example: 150000.5,
+    type: 'number',
+  })
+  totalVolume: number;
+
+  @ApiProperty({
+    description: 'Total number of payments',
+    example: 342,
+    type: 'integer',
+  })
+  totalCount: number;
+
+  @ApiProperty({
+    description: 'Average payment amount',
+    example: 438.6,
+    type: 'number',
+  })
+  averageAmount: number;
+
+  @ApiProperty({
+    description: 'Period used for the aggregation',
+    example: 'month',
+  })
+  period: string;
+
+  @ApiProperty({
+    description: 'Start of the period (ISO 8601)',
+    example: '2026-07-01T00:00:00.000Z',
+  })
+  periodStart: string;
+
+  @ApiProperty({
+    description: 'End of the period (ISO 8601)',
+    example: '2026-07-31T23:59:59.999Z',
+  })
+  periodEnd: string;
+}
+
+export class CurrencyBreakdownItemDto {
+  @ApiProperty({ description: 'Currency code', example: 'USD' })
+  currency: string;
+
+  @ApiProperty({
+    description: 'Total volume for this currency',
+    example: 85000.0,
+    type: 'number',
+  })
+  totalVolume: number;
+
+  @ApiProperty({
+    description: 'Number of payments in this currency',
+    example: 200,
+    type: 'integer',
+  })
+  count: number;
+
+  @ApiProperty({
+    description: 'Average amount in this currency',
+    example: 425.0,
+    type: 'number',
+  })
+  averageAmount: number;
+}
+
+export class CurrencyBreakdownDto {
+  @ApiProperty({
+    description: 'Breakdown of payments by currency',
+    type: [CurrencyBreakdownItemDto],
+  })
+  breakdown: CurrencyBreakdownItemDto[];
+
+  @ApiProperty({ description: 'Period used for the aggregation', example: 'month' })
+  period: string;
+
+  @ApiProperty({
+    description: 'Start of the period (ISO 8601)',
+    example: '2026-07-01T00:00:00.000Z',
+  })
+  periodStart: string;
+
+  @ApiProperty({
+    description: 'End of the period (ISO 8601)',
+    example: '2026-07-31T23:59:59.999Z',
+  })
+  periodEnd: string;
+}
+
+export class StatusBreakdownItemDto {
+  @ApiProperty({ description: 'Payment status', example: 'COMPLETED' })
+  status: string;
+
+  @ApiProperty({
+    description: 'Number of payments with this status',
+    example: 280,
+    type: 'integer',
+  })
+  count: number;
+
+  @ApiProperty({
+    description: 'Percentage of total payments',
+    example: 81.87,
+    type: 'number',
+  })
+  percentage: number;
+
+  @ApiProperty({
+    description: 'Total volume for this status',
+    example: 120000.0,
+    type: 'number',
+  })
+  totalVolume: number;
+}
+
+export class StatusBreakdownDto {
+  @ApiProperty({
+    description: 'Breakdown of payments by status',
+    type: [StatusBreakdownItemDto],
+  })
+  breakdown: StatusBreakdownItemDto[];
+
+  @ApiProperty({
+    description: 'Overall success rate (COMPLETED / total)',
+    example: 81.87,
+    type: 'number',
+  })
+  successRate: number;
+
+  @ApiProperty({
+    description: 'Overall failure rate (FAILED / total)',
+    example: 5.26,
+    type: 'number',
+  })
+  failureRate: number;
+
+  @ApiProperty({ description: 'Period used for the aggregation', example: 'month' })
+  period: string;
+
+  @ApiProperty({
+    description: 'Start of the period (ISO 8601)',
+    example: '2026-07-01T00:00:00.000Z',
+  })
+  periodStart: string;
+
+  @ApiProperty({
+    description: 'End of the period (ISO 8601)',
+    example: '2026-07-31T23:59:59.999Z',
+  })
+  periodEnd: string;
+}

--- a/src/modules/payments/payment.entity.ts
+++ b/src/modules/payments/payment.entity.ts
@@ -20,6 +20,13 @@ export class Payment {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
+  /**
+   * The ID of the merchant/user who created this payment.
+   * Nullable for backward compatibility with payments created before this field was added.
+   */
+  @Column({ nullable: true })
+  userId: string | null = null;
+
   @Column({ type: 'decimal', precision: 10, scale: 2 })
   amount: number;
 


### PR DESCRIPTION
 Payment Analytics Endpoints
  
  Summary
  
  Adds a new /v1/analytics module that gives merchants aggregated payment insights scoped to
  their account. Results are cached in Redis with a 60-second TTL to reduce database load.
  
  Endpoints
  
  ┌────────┬───────────────────────────────┬─────────────────────────────────────────────────┐
  │ Method │ Path                          │ Description                                     │
  ├────────┼───────────────────────────────┼─────────────────────────────────────────────────┤
  │ GET    │ /v1/analytics/payments        │ Total volume, count, and average amount         │
  ├────────┼───────────────────────────────┼─────────────────────────────────────────────────┤
  │ GET    │ /v1/analytics/payments/by-cur │ Volume and count broken down per currency       │
  │        │ rency                         │                                                 │
  ├────────┼───────────────────────────────┼─────────────────────────────────────────────────┤
  │ GET    │ /v1/analytics/payments/by-sta │ Count and volume per status, plus               │
  │        │ tus                           │ success/failure rates                           │
  └────────┴───────────────────────────────┴─────────────────────────────────────────────────┘
  
  All endpoints accept a ?period=day|week|month|year query param (defaults to month) and require
  a valid JWT.
  
  Changes
  
  - New module — src/modules/analytics/ with controller, service, cache service, and DTOs
  - Payment entity — Added nullable userId column to scope payments per merchant
  - Migration — 1752000000000-AddUserIdToPayments adds the userId column and index to the
  payments table
  - AppModule — Registered AnalyticsModule; fixed pre-existing missing ConfigService import in
  BullModule.forRootAsync
  
  Technical Notes
  
  - Queries use TypeORM createQueryBuilder with GROUP BY on currency and status
  - Redis caching via ioredis (available as a transitive BullMQ dependency) — cache failures
  degrade gracefully to live queries
  - userId on Payment is nullable for backward compatibility with existing records
  
  Testing
  
  curl -H "Authorization: Bearer <token>"
  "http://localhost:3000/v1/analytics/payments?period=month"
  curl -H "Authorization: Bearer <token>"
  "http://localhost:3000/v1/analytics/payments/by-currency?period=week"
  curl -H "Authorization: Bearer <token>"
  "http://localhost:3000/v1/analytics/payments/by-status?period=day"


closes #161 