### PR TITLE
feat: resolve issues #63, #65, #66, #216

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,9 +45,9 @@ APP_URL=http://localhost:3000
 
 # CORS Configuration
 # Comma-separated list of allowed origins (leave empty to disable CORS)
-ALLOWED_ORIGINS=http://localhost:3000,https://app.facilpay.com
-# Set to "true" to allow credentials (cookies, auth headers)
-CORS_CREDENTIALS=true
+CORS_ALLOWED_ORIGINS=http://localhost:3000,https://app.facilpay.com
+# Set to "true" to allow credentials (cookies, auth headers) — opt-in only
+CORS_ALLOW_CREDENTIALS=false
 
 # Redis Configuration
 REDIS_HOST=localhost

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,5 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { DatabaseModule } from './modules/database/database.module';
 import { HealthModule } from './modules/health/health.module';
 import { AuthModule } from './modules/auth/auth.module';
@@ -20,6 +20,7 @@ import { ApiKeysModule } from './modules/api-keys/api-keys.module';
 import { NotificationsModule } from './modules/notifications/notifications.module';
 import { RatesModule } from './modules/rates/rates.module';
 import { MerchantsModule } from './modules/merchants/merchants.module';
+import { SecurityHeadersMiddleware } from './common/middleware/security-headers.middleware';
 
 @Module({
   imports: [
@@ -55,6 +56,6 @@ import { MerchantsModule } from './modules/merchants/merchants.module';
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    consumer.apply(HttpLoggerMiddleware).forRoutes('*');
+    consumer.apply(SecurityHeadersMiddleware, HttpLoggerMiddleware).forRoutes('*');
   }
 }

--- a/src/common/middleware/security-headers.middleware.ts
+++ b/src/common/middleware/security-headers.middleware.ts
@@ -1,0 +1,31 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+
+/**
+ * Applies security-related HTTP response headers equivalent to helmet defaults,
+ * without requiring the helmet dependency.
+ */
+@Injectable()
+export class SecurityHeadersMiddleware implements NestMiddleware {
+  use(_req: Request, res: Response, next: NextFunction) {
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('X-Frame-Options', 'SAMEORIGIN');
+    res.setHeader('X-XSS-Protection', '0'); // Disabled per modern guidance; rely on CSP
+    res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+    res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
+    res.setHeader(
+      'Content-Security-Policy',
+      "default-src 'self'; base-uri 'self'; font-src 'self' https: data:; " +
+        "form-action 'self'; frame-ancestors 'self'; img-src 'self' data:; " +
+        "object-src 'none'; script-src 'self'; script-src-attr 'none'; " +
+        "style-src 'self' https: 'unsafe-inline'; upgrade-insecure-requests",
+    );
+    res.setHeader(
+      'Strict-Transport-Security',
+      'max-age=15552000; includeSubDomains',
+    );
+    res.removeHeader('X-Powered-By');
+    next();
+  }
+}

--- a/src/modules/cors/cors-config.service.ts
+++ b/src/modules/cors/cors-config.service.ts
@@ -2,6 +2,7 @@ import { Injectable, BadRequestException } from '@nestjs/common';
 import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
 import { CorsConfig } from './cors-config.interface';
+import type { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
 
 @Injectable()
 export class CorsConfigService {
@@ -12,18 +13,19 @@ export class CorsConfigService {
   }
 
   private loadConfig(): CorsConfig {
-    const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',').filter(Boolean) || [];
-    const credentials = process.env.CORS_CREDENTIALS === 'true';
+    // Support both CORS_ALLOWED_ORIGINS (new) and ALLOWED_ORIGINS (legacy)
+    const rawOrigins = process.env.CORS_ALLOWED_ORIGINS ?? process.env.ALLOWED_ORIGINS ?? '';
+    const allowedOrigins = rawOrigins.split(',').map((o) => o.trim()).filter(Boolean);
+    const credentials = process.env.CORS_ALLOW_CREDENTIALS === 'true';
 
     const configData = {
       allowedOrigins,
       credentials,
       allowedMethods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
-      allowedHeaders: ['Content-Type', 'Authorization'],
+      allowedHeaders: ['Content-Type', 'Authorization', 'X-Correlation-Id'],
     };
 
-    const config = plainToInstance(CorsConfig, configData);
-    return config;
+    return plainToInstance(CorsConfig, configData);
   }
 
   async validate(): Promise<string[]> {
@@ -56,13 +58,22 @@ export class CorsConfigService {
     return this.config.allowedHeaders || ['Content-Type', 'Authorization'];
   }
 
-  getCorsOptions(): object {
+  getCorsOptions(): CorsOptions {
     const allowedOrigins = this.getAllowedOrigins();
+    const credentials = this.getCredentials();
+
     return {
-      origin: allowedOrigins.length > 0 ? allowedOrigins : false,
-      credentials: this.getCredentials(),
+      // Strict allowlist: only listed origins pass; unlisted get no ACAO header
+      origin: (origin, callback) => {
+        // Allow server-to-server requests (no Origin header)
+        if (!origin) return callback(null, true);
+        if (allowedOrigins.includes(origin)) return callback(null, true);
+        callback(null, false);
+      },
+      credentials,
       methods: this.getAllowedMethods(),
       allowedHeaders: this.getAllowedHeaders(),
+      exposedHeaders: ['X-Correlation-Id'],
     };
   }
 }

--- a/src/modules/logger/correlation-id.context.ts
+++ b/src/modules/logger/correlation-id.context.ts
@@ -1,0 +1,7 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export const correlationIdStorage = new AsyncLocalStorage<string>();
+
+export function getCorrelationId(): string | undefined {
+  return correlationIdStorage.getStore();
+}

--- a/src/modules/logger/http-logger.middleware.ts
+++ b/src/modules/logger/http-logger.middleware.ts
@@ -11,6 +11,7 @@ import {
   sanitizeHeaders,
 } from './logging.utils';
 import { Logger } from 'pino';
+import { correlationIdStorage } from './correlation-id.context';
 
 const DEFAULT_BODY_MAX_LENGTH = 2048;
 
@@ -36,8 +37,13 @@ export class HttpLoggerMiddleware implements NestMiddleware {
 
   use(req: Request, res: Response, next: NextFunction) {
     const requestId = getRequestId(req.headers) ?? randomUUID();
+    // Accept upstream X-Correlation-Id or generate a fresh one
+    const correlationId =
+      (req.headers['x-correlation-id'] as string | undefined)?.trim() || randomUUID();
+
     req.requestId = requestId;
     res.setHeader('x-request-id', requestId);
+    res.setHeader('x-correlation-id', correlationId);
 
     const startTime = process.hrtime.bigint();
     let responseBody: unknown;
@@ -57,74 +63,79 @@ export class HttpLoggerMiddleware implements NestMiddleware {
       };
     }
 
-    res.on('finish', () => {
-      const durationMs = Number(process.hrtime.bigint() - startTime) / 1e6;
-      const statusCode = res.statusCode;
-      const path = req.originalUrl ?? req.url;
-      const userId = extractUserId(req.user);
+    // Run the rest of the request lifecycle inside the AsyncLocalStorage context
+    // so all log calls within this request automatically carry the correlationId
+    correlationIdStorage.run(correlationId, () => {
+      res.on('finish', () => {
+        const durationMs = Number(process.hrtime.bigint() - startTime) / 1e6;
+        const statusCode = res.statusCode;
+        const path = req.originalUrl ?? req.url;
+        const userId = extractUserId(req.user);
 
-      const meta: Record<string, unknown> = {
-        requestId,
-        method: req.method,
-        path,
-        statusCode,
-        durationMs: Number(durationMs.toFixed(2)),
-        userId,
-      };
+        const meta: Record<string, unknown> = {
+          correlationId,
+          requestId,
+          method: req.method,
+          path,
+          statusCode,
+          durationMs: Number(durationMs.toFixed(2)),
+          userId,
+        };
 
-      const requestMeta: Record<string, unknown> = {};
-      const sanitizedHeaders = sanitizeHeaders(req.headers);
-      if (sanitizedHeaders) {
-        requestMeta.headers = sanitizedHeaders;
-      }
-
-      if (this.logBody) {
-        const sanitizedBody = sanitizeBody(req.body, this.bodyMaxLength);
-        if (sanitizedBody !== undefined) {
-          requestMeta.body = sanitizedBody;
+        const requestMeta: Record<string, unknown> = {};
+        const sanitizedHeaders = sanitizeHeaders(req.headers);
+        if (sanitizedHeaders) {
+          requestMeta.headers = sanitizedHeaders;
         }
-      }
 
-      if (Object.keys(requestMeta).length > 0) {
-        meta.request = requestMeta;
-      }
-
-      const responseMeta: Record<string, unknown> = {};
-      const contentLength = getContentLength(res);
-      if (contentLength !== undefined) {
-        responseMeta.contentLength = contentLength;
-      }
-
-      if (this.logResponseBody) {
-        const sanitizedResponseBody = sanitizeBody(
-          responseBody,
-          this.bodyMaxLength,
-        );
-        if (sanitizedResponseBody !== undefined) {
-          responseMeta.body = sanitizedResponseBody;
+        if (this.logBody) {
+          const sanitizedBody = sanitizeBody(req.body, this.bodyMaxLength);
+          if (sanitizedBody !== undefined) {
+            requestMeta.body = sanitizedBody;
+          }
         }
-      }
 
-      if (Object.keys(responseMeta).length > 0) {
-        meta.response = responseMeta;
-      }
+        if (Object.keys(requestMeta).length > 0) {
+          meta.request = requestMeta;
+        }
 
-      if (statusCode >= 400) {
-        meta.error = normalizeErrorContext(res.locals?.error);
-      }
+        const responseMeta: Record<string, unknown> = {};
+        const contentLength = getContentLength(res);
+        if (contentLength !== undefined) {
+          responseMeta.contentLength = contentLength;
+        }
 
-      const message = `${req.method} ${path} ${statusCode} ${durationMs.toFixed(1)}ms`;
+        if (this.logResponseBody) {
+          const sanitizedResponseBody = sanitizeBody(
+            responseBody,
+            this.bodyMaxLength,
+          );
+          if (sanitizedResponseBody !== undefined) {
+            responseMeta.body = sanitizedResponseBody;
+          }
+        }
 
-      if (statusCode >= 500) {
-        this.logger.error(meta, message);
-      } else if (statusCode >= 400) {
-        this.logger.warn(meta, message);
-      } else {
-        this.logger.info(meta, message);
-      }
+        if (Object.keys(responseMeta).length > 0) {
+          meta.response = responseMeta;
+        }
+
+        if (statusCode >= 400) {
+          meta.error = normalizeErrorContext(res.locals?.error);
+        }
+
+        const message = `${req.method} ${path} ${statusCode} ${durationMs.toFixed(1)}ms`;
+
+        if (statusCode >= 500) {
+          this.logger.error(meta, message);
+        } else if (statusCode >= 400) {
+          this.logger.warn(meta, message);
+        } else {
+          this.logger.info(meta, message);
+        }
+      });
+
+      next();
     });
-
-    next();
   }
 }
 

--- a/src/modules/logger/logger.service.ts
+++ b/src/modules/logger/logger.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { mkdirSync } from 'node:fs';
 import pino, { Logger } from 'pino';
 import { buildLoggerConfig, buildTransportTargets } from './logger.config';
+import { getCorrelationId } from './correlation-id.context';
 
 @Injectable()
 export class AppLogger implements LoggerService {
@@ -43,22 +44,22 @@ export class AppLogger implements LoggerService {
   }
 
   log(message: any, context?: string) {
-    this.logger.info({ context }, message);
+    this.logger.info({ context, correlationId: getCorrelationId() }, message);
   }
 
   error(message: any, trace?: string, context?: string) {
-    this.logger.error({ context, trace }, message);
+    this.logger.error({ context, trace, correlationId: getCorrelationId() }, message);
   }
 
   warn(message: any, context?: string) {
-    this.logger.warn({ context }, message);
+    this.logger.warn({ context, correlationId: getCorrelationId() }, message);
   }
 
   debug(message: any, context?: string) {
-    this.logger.debug({ context }, message);
+    this.logger.debug({ context, correlationId: getCorrelationId() }, message);
   }
 
   verbose(message: any, context?: string) {
-    this.logger.trace({ context }, message);
+    this.logger.trace({ context, correlationId: getCorrelationId() }, message);
   }
 }

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -137,12 +137,40 @@ export class UsersController {
     return this.usersService.updateProfile(user.id, updateUserDto);
   }
 
+  @UseGuards(JwtAuthGuard)
+  @Get('me')
+  @ApiBearerAuth('bearer')
+  @ApiOperation({
+    summary: 'Get current user profile',
+    description: 'Returns the authenticated user\'s profile. Password and 2FA secret are never included.',
+  })
+  @ApiOkResponse({
+    description: 'Authenticated user profile.',
+    schema: {
+      example: {
+        id: 'abc123',
+        email: 'jane.doe@example.com',
+        name: 'Jane Doe',
+        roles: ['USER'],
+        isEmailVerified: true,
+        isActive: true,
+        createdAt: '2026-01-26T10:00:00.000Z',
+        updatedAt: '2026-01-26T10:00:00.000Z',
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Missing/invalid access token.',
+    schema: { example: { statusCode: 401, message: 'Unauthorized' } },
+  })
+  getMe(@CurrentUser() user: User) {
+    return this.usersService.findOne(user.id);
+  }
+
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.ADMIN)
   @Get()
   @ApiBearerAuth('bearer')
-  @ApiOperation({
-    summary: 'List users',
     description:
       'Returns paginated users (passwords are never returned). Admin only.',
   })

--- a/src/modules/webhooks/webhooks.service.ts
+++ b/src/modules/webhooks/webhooks.service.ts
@@ -89,7 +89,7 @@ export class WebhooksService {
   }
 
   async dispatchEventToMerchant(merchantId: string, event: string, data: any): Promise<void> {
-    const endpoints = await this.repo.find({ where: { merchantId } });
+    const endpoints = await this.repo.find({ where: { merchantId, isActive: true } });
     const payload = {
       event,
       timestamp: new Date().toISOString(),
@@ -97,8 +97,10 @@ export class WebhooksService {
     };
 
     for (const endpoint of endpoints) {
-      // Check if endpoint is enabled or filtered by event (assuming all are sent if no filter)
-      await this.dispatchEventToEndpoint(endpoint, payload);
+      // Only deliver to endpoints subscribed to this event type
+      if (endpoint.events.includes(event as any)) {
+        await this.dispatchEventToEndpoint(endpoint, payload);
+      }
     }
   }
 


### PR DESCRIPTION
closes #63 
closes #65 
closes #66 
closes #216 

- fix(cors #65): rename env var to CORS_ALLOWED_ORIGINS, enforce strict origin allowlist via callback (unlisted origins get no ACAO header), make credentials opt-in via CORS_ALLOW_CREDENTIALS, expose X-Correlation-Id header, add SecurityHeadersMiddleware (CSP, X-Frame-Options, X-Content-Type-Options, HSTS, etc.) without helmet

- feat(logging #63): add AsyncLocalStorage-based correlation ID context, accept/propagate upstream X-Correlation-Id header, generate UUID when absent, set X-Correlation-Id response header, inject correlationId into every log entry via AppLogger and HttpLoggerMiddleware

- feat(users #66): add GET /v1/users/me endpoint protected by JwtAuthGuard; resolves authenticated user profile from JWT sub claim, excludes password/twoFactorSecret, returns 401 on missing/invalid token, documented with @ApiBearerAuth in Swagger

- feat(webhooks #216): filter dispatchEventToMerchant delivery by subscription event types so endpoints only receive events they opted into; also restricts dispatch to isActive endpoints only

Closes #63, #65, #66, #216