### PR TITLE
 Title: Add refund actor tracking, payments pagination docs, recurring payments, and per-API-key rate limits 

### DIFF
--- a/src/migrations/1754100000000-CreateRecurringPaymentsTable.ts
+++ b/src/migrations/1754100000000-CreateRecurringPaymentsTable.ts
@@ -1,0 +1,112 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateRecurringPaymentsTable1754100000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'recurring_payments',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'amount',
+            type: 'decimal',
+            precision: 10,
+            scale: 2,
+          },
+          {
+            name: 'currency',
+            type: 'varchar',
+          },
+          {
+            name: 'interval',
+            type: 'enum',
+            enum: ['daily', 'weekly', 'monthly'],
+          },
+          {
+            name: 'status',
+            type: 'enum',
+            enum: ['active', 'paused', 'cancelled'],
+            default: `'active'`,
+          },
+          {
+            name: 'description',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'merchantId',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'merchantEmail',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'payerEmail',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'callbackUrl',
+            type: 'varchar',
+            length: '2048',
+            isNullable: true,
+          },
+          {
+            name: 'metadata',
+            type: 'jsonb',
+            isNullable: true,
+          },
+          {
+            name: 'createdBy',
+            type: 'varchar',
+          },
+          {
+            name: 'nextRunAt',
+            type: 'timestamp',
+          },
+          {
+            name: 'lastRunAt',
+            type: 'timestamp',
+            isNullable: true,
+          },
+          {
+            name: 'cancelledAt',
+            type: 'timestamp',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.query(
+      `CREATE INDEX "idx_recurring_payments_due" ON "recurring_payments" ("status", "nextRunAt")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('recurring_payments');
+  }
+}

--- a/src/modules/api-keys/api-key.entity.ts
+++ b/src/modules/api-keys/api-key.entity.ts
@@ -60,6 +60,22 @@ export class ApiKey {
   @ApiProperty({ example: true })
   isActive: boolean;
 
+  @Column({ type: 'int', nullable: true })
+  @ApiPropertyOptional({
+    description:
+      'Custom requests-per-window limit for this key. When set, overrides the global default rate limit.',
+    example: 500,
+  })
+  rateLimitLimit: number | null;
+
+  @Column({ type: 'int', nullable: true })
+  @ApiPropertyOptional({
+    description:
+      'Window size in milliseconds for rateLimitLimit. Defaults to the global window when not set.',
+    example: 60000,
+  })
+  rateLimitTtl: number | null;
+
   @CreateDateColumn()
   @ApiProperty()
   createdAt: Date;

--- a/src/modules/api-keys/api-keys.controller.ts
+++ b/src/modules/api-keys/api-keys.controller.ts
@@ -82,9 +82,9 @@ export class ApiKeysController {
 
   @Patch(':id')
   @ApiOperation({
-    summary: "Update an API key's name and/or scope",
+    summary: "Update an API key's name, scope, and/or rate limit override",
     description:
-      'Updates the name and/or scope of an existing API key without regenerating its secret. Scope changes take effect immediately for subsequent requests.',
+      'Updates the name, scope, and/or custom rate limit of an existing API key without regenerating its secret. Changes take effect immediately for subsequent requests.',
   })
   @ApiBody({ type: UpdateApiKeyDto })
   @ApiOkResponse({ description: 'API key updated.', type: ApiKey })
@@ -109,19 +109,6 @@ export class ApiKeysController {
     @CurrentUser() user: User,
   ): Promise<void> {
     return this.apiKeysService.revoke(id, user.id);
-  }
-
-  @Patch(':id')
-  @ApiOperation({ summary: 'Rename or change an API key\'s scope' })
-  @ApiOkResponse({ description: 'API key updated.', type: ApiKey })
-  @ApiNotFoundResponse({ description: 'API key not found.' })
-  @ApiUnauthorizedResponse({ description: 'Missing or invalid bearer token.' })
-  async update(
-    @Param('id') id: string,
-    @CurrentUser() user: User,
-    @Body() dto: UpdateApiKeyDto,
-  ): Promise<ApiKey> {
-    return this.apiKeysService.update(id, user.id, dto);
   }
 
   @Post(':id/rotate')

--- a/src/modules/api-keys/api-keys.service.ts
+++ b/src/modules/api-keys/api-keys.service.ts
@@ -38,6 +38,8 @@ export class ApiKeysService {
       expiresAt: dto.expiresAt ? new Date(dto.expiresAt) : null,
       lastUsedAt: null,
       isActive: true,
+      rateLimitLimit: dto.rateLimitLimit ?? null,
+      rateLimitTtl: dto.rateLimitTtl ?? null,
     });
 
     const saved = await this.apiKeyRepository.save(apiKey);
@@ -49,20 +51,6 @@ export class ApiKeysService {
       where: { userId, isActive: true },
       order: { createdAt: 'DESC' },
     });
-  }
-
-  async update(id: string, userId: string, dto: UpdateApiKeyDto): Promise<ApiKey> {
-    const key = await this.apiKeyRepository.findOne({ where: { id, userId } });
-    if (!key) {
-      throw new NotFoundException(`API key with ID ${id} not found`);
-    }
-    if (dto.name !== undefined) {
-      key.name = dto.name;
-    }
-    if (dto.scope !== undefined) {
-      key.scope = dto.scope;
-    }
-    return this.apiKeyRepository.save(key);
   }
 
   async revoke(id: string, userId: string): Promise<void> {
@@ -81,6 +69,8 @@ export class ApiKeysService {
     }
     if (dto.name !== undefined) key.name = dto.name;
     if (dto.scope !== undefined) key.scope = dto.scope;
+    if (dto.rateLimitLimit !== undefined) key.rateLimitLimit = dto.rateLimitLimit;
+    if (dto.rateLimitTtl !== undefined) key.rateLimitTtl = dto.rateLimitTtl;
     return this.apiKeyRepository.save(key);
   }
 

--- a/src/modules/api-keys/dto/create-api-key.dto.ts
+++ b/src/modules/api-keys/dto/create-api-key.dto.ts
@@ -2,8 +2,10 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsEnum,
   IsISO8601,
+  IsInt,
   IsNotEmpty,
   IsOptional,
+  IsPositive,
   IsString,
   MaxLength,
 } from 'class-validator';
@@ -33,4 +35,26 @@ export class CreateApiKeyDto {
   @IsISO8601()
   @IsOptional()
   expiresAt?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Custom requests-per-window limit for this key. Overrides the global default rate limit when set.',
+    example: 500,
+    minimum: 1,
+  })
+  @IsInt()
+  @IsPositive()
+  @IsOptional()
+  rateLimitLimit?: number;
+
+  @ApiPropertyOptional({
+    description:
+      'Window size in milliseconds for rateLimitLimit. Defaults to the global window when not set.',
+    example: 60000,
+    minimum: 1,
+  })
+  @IsInt()
+  @IsPositive()
+  @IsOptional()
+  rateLimitTtl?: number;
 }

--- a/src/modules/api-keys/dto/update-api-key.dto.ts
+++ b/src/modules/api-keys/dto/update-api-key.dto.ts
@@ -1,5 +1,12 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsPositive,
+  IsString,
+  MaxLength,
+} from 'class-validator';
 import { ApiKeyScope } from '../api-key.entity';
 
 export class UpdateApiKeyDto {
@@ -13,4 +20,26 @@ export class UpdateApiKeyDto {
   @IsEnum(ApiKeyScope)
   @IsOptional()
   scope?: ApiKeyScope;
+
+  @ApiPropertyOptional({
+    description:
+      'Custom requests-per-window limit for this key. Overrides the global default rate limit when set.',
+    example: 500,
+    minimum: 1,
+  })
+  @IsInt()
+  @IsPositive()
+  @IsOptional()
+  rateLimitLimit?: number;
+
+  @ApiPropertyOptional({
+    description:
+      'Window size in milliseconds for rateLimitLimit. Defaults to the global window when not set.',
+    example: 60000,
+    minimum: 1,
+  })
+  @IsInt()
+  @IsPositive()
+  @IsOptional()
+  rateLimitTtl?: number;
 }

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Post,
   Get,
+  Patch,
   Body,
   Query,
   Param,

--- a/src/modules/payments/dto/create-recurring-payment.dto.ts
+++ b/src/modules/payments/dto/create-recurring-payment.dto.ts
@@ -1,0 +1,114 @@
+import {
+  IsNumber,
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsUrl,
+  IsEmail,
+  IsEnum,
+  IsObject,
+  IsISO8601,
+  Min,
+  MaxLength,
+  IsPositive,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsISO4217CurrencyCode } from '../../../common/validators/is-iso4217-currency-code.validator';
+import { RecurringPaymentInterval } from '../recurring-payment.entity';
+
+export class CreateRecurringPaymentDto {
+  @IsNumber()
+  @IsNotEmpty()
+  @IsPositive({ message: 'Amount must be a positive number' })
+  @Min(0.01, { message: 'Amount must be at least 0.01' })
+  @ApiProperty({
+    description: 'Amount to charge on each scheduled run',
+    example: 29.99,
+    minimum: 0.01,
+  })
+  amount: number;
+
+  @IsString()
+  @IsNotEmpty({ message: 'Currency is required' })
+  @IsISO4217CurrencyCode({ supportedOnly: true })
+  @ApiProperty({
+    description: 'Currency code (ISO 4217). Must be supported by this API instance.',
+    example: 'USD',
+    maxLength: 3,
+  })
+  currency: string;
+
+  @IsEnum(RecurringPaymentInterval, {
+    message:
+      'interval must be one of: ' +
+      Object.values(RecurringPaymentInterval).join(', '),
+  })
+  @ApiProperty({
+    enum: RecurringPaymentInterval,
+    description: 'How often the plan generates a new payment',
+    example: RecurringPaymentInterval.MONTHLY,
+  })
+  interval: RecurringPaymentInterval;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(500, { message: 'Description must not exceed 500 characters' })
+  @ApiPropertyOptional({
+    description: 'Optional description applied to each generated payment',
+    example: 'Monthly subscription',
+    maxLength: 500,
+  })
+  description?: string;
+
+  @IsString()
+  @IsOptional()
+  @ApiPropertyOptional({
+    description: 'ID of the merchant this recurring plan belongs to',
+    example: 'abc123-merchant-uuid',
+  })
+  merchantId?: string;
+
+  @IsEmail()
+  @IsOptional()
+  @ApiPropertyOptional({
+    description: 'Merchant email for notifications on each generated payment',
+    example: 'merchant@example.com',
+  })
+  merchantEmail?: string;
+
+  @IsEmail()
+  @IsOptional()
+  @ApiPropertyOptional({
+    description: 'Payer email for notifications on each generated payment',
+    example: 'payer@example.com',
+  })
+  payerEmail?: string;
+
+  @IsUrl({}, { message: 'callbackUrl must be a valid URL' })
+  @IsOptional()
+  @ApiPropertyOptional({
+    description: 'Webhook callback URL applied to each generated payment',
+    example: 'https://merchant.example.com/webhooks/payment',
+    maxLength: 2048,
+  })
+  callbackUrl?: string;
+
+  @IsObject()
+  @IsOptional()
+  @ApiPropertyOptional({
+    description: 'Arbitrary key-value metadata applied to each generated payment',
+    example: { orderId: 'sub_123' },
+    type: 'object',
+    additionalProperties: { type: 'string' },
+  })
+  metadata?: Record<string, string>;
+
+  @IsISO8601({}, { message: 'startAt must be a valid ISO 8601 date' })
+  @IsOptional()
+  @ApiPropertyOptional({
+    description:
+      'When the first charge should run. Defaults to immediately (next scheduler tick) when omitted.',
+    example: '2026-08-01T00:00:00Z',
+  })
+  startAt?: string;
+}

--- a/src/modules/payments/dto/get-payments.dto.ts
+++ b/src/modules/payments/dto/get-payments.dto.ts
@@ -90,7 +90,7 @@ export class GetPaymentsDto extends PaginationDto {
   })
   @IsString()
   @IsOptional()
-  search?: string;
+  declare search?: string;
 
   @ApiPropertyOptional({
     description: 'Filter by metadata key-value pair, e.g. metadata[orderId]=order_123',

--- a/src/modules/payments/dto/refund-payment.dto.ts
+++ b/src/modules/payments/dto/refund-payment.dto.ts
@@ -30,12 +30,4 @@ export class RefundPaymentDto {
     maxLength: 500,
   })
   reason?: string;
-
-  @IsString()
-  @IsOptional()
-  @ApiPropertyOptional({
-    description: 'User ID or system actor that initiated the refund',
-    example: 'admin-user-id',
-  })
-  initiatedBy?: string;
 }

--- a/src/modules/payments/payment.entity.ts
+++ b/src/modules/payments/payment.entity.ts
@@ -42,7 +42,7 @@ export class Payment {
   @Column({ nullable: true })
   description: string;
 
-  @Column({ nullable: true, length: 2048 })
+  @Column({ type: 'varchar', nullable: true, length: 2048 })
   callbackUrl: string | null;
 
   @Column({ type: 'decimal', precision: 10, scale: 2, default: 0 })

--- a/src/modules/payments/payments.controller.ts
+++ b/src/modules/payments/payments.controller.ts
@@ -529,6 +529,7 @@ export class PaymentsController {
   }
 
   @Post(':id/refund')
+  @UseGuards(JwtAuthGuard)
   @ApiBearerAuth('bearer')
   @ApiOperation({
     summary: 'Refund a payment',
@@ -559,6 +560,7 @@ export class PaymentsController {
           paymentId: '123e4567-e89b-12d3-a456-426614174000',
           amount: '100.00',
           reason: 'Customer requested refund',
+          initiatedBy: '789e0123-e89b-12d3-a456-426614174000',
           createdAt: '2026-01-26T11:00:00.000Z',
         },
       },
@@ -603,8 +605,12 @@ export class PaymentsController {
       example: { statusCode: 500, message: 'Internal server error' },
     },
   })
-  refund(@Param('id') id: string, @Body() refundDto: RefundPaymentDto) {
-    return this.paymentsService.refund(id, refundDto);
+  refund(
+    @Param('id') id: string,
+    @Body() refundDto: RefundPaymentDto,
+    @Req() req: Request & { user?: { id: string } },
+  ) {
+    return this.paymentsService.refund(id, refundDto, req.user?.id);
   }
 
   @Post(':id/cancel')

--- a/src/modules/payments/payments.module.ts
+++ b/src/modules/payments/payments.module.ts
@@ -22,6 +22,12 @@ import { PaymentQrController } from './payment-qr.controller';
 import { MerchantFeeConfig } from './merchant-fee-config.entity';
 import { PaymentLinksModule } from '../payment-links/payment-links.module';
 import { DisputesService } from './disputes.service';
+import { DisputesController } from './disputes.controller';
+import { Dispute } from './dispute.entity';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { RecurringPayment } from './recurring-payment.entity';
+import { RecurringPaymentsService } from './recurring-payments.service';
+import { RecurringPaymentsController } from './recurring-payments.controller';
 
 @Module({
   imports: [
@@ -34,6 +40,7 @@ import { DisputesService } from './disputes.service';
       PaymentSplit,
       MerchantFeeConfig,
       Dispute,
+      RecurringPayment,
     ]),
     WebhooksModule,
     StellarModule,
@@ -46,7 +53,7 @@ import { DisputesService } from './disputes.service';
     CurrenciesController,
     PaymentQrController,
     DisputesController,
-    PaymentsAnalyticsController,
+    RecurringPaymentsController,
   ],
   providers: [
     PaymentsService,
@@ -57,7 +64,7 @@ import { DisputesService } from './disputes.service';
     IdempotencyInterceptor,
     CurrencyConfigService,
     PaymentSseService,
-    PaymentsAnalyticsService,
+    RecurringPaymentsService,
   ],
   exports: [
     PaymentsService,

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -9,9 +9,13 @@ import { AppLogger } from '../logger/logger.service';
 import { IdempotencyService } from './idempotency.service';
 import { EmailNotificationService } from '../notifications/email-notification.service';
 import { PaymentSplit } from './payment-split.entity';
+import { MerchantFeeConfig } from './merchant-fee-config.entity';
 import { WebhooksService } from '../webhooks/webhooks.service';
 import { StellarService } from '../stellar/stellar.service';
 import { ConfigService } from '@nestjs/config';
+import { PaymentSseService } from './payment-sse.service';
+import { GetPaymentsDto, PaymentSortBy } from './dto/get-payments.dto';
+import { SortOrder } from '../../common/dto/pagination.dto';
 
 describe('PaymentsService', () => {
   let service: PaymentsService;
@@ -153,6 +157,14 @@ describe('PaymentsService', () => {
         {
           provide: getRepositoryToken(PaymentSplit),
           useValue: { create: jest.fn(), save: jest.fn(), find: jest.fn(), findOneBy: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(MerchantFeeConfig),
+          useValue: { create: jest.fn(), save: jest.fn(), find: jest.fn(), findOneBy: jest.fn() },
+        },
+        {
+          provide: PaymentSseService,
+          useValue: mockPaymentSseService,
         },
         {
           provide: WebhooksService,
@@ -480,7 +492,7 @@ describe('PaymentsService', () => {
       expect(queryBuilderMock.andWhere).toHaveBeenCalledWith(
         expect.stringContaining('payment.createdAt < :cursorValue'),
         expect.objectContaining({
-          cursorValue: mockPayment1.createdAt,
+          cursorValue: mockPayment1.createdAt.toISOString(),
           cursorId: mockPayment1.id,
         }),
       );

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -574,6 +574,7 @@ export class PaymentsService {
   async refund(
     id: string,
     refundDto: RefundPaymentDto,
+    initiatedBy?: string,
   ): Promise<{ payment: Payment; refund: Refund }> {
     const queryRunner = this.dataSource.createQueryRunner();
 
@@ -617,7 +618,7 @@ export class PaymentsService {
         paymentId: id,
         amount: refundAmount,
         reason: refundDto.reason,
-        initiatedBy: refundDto.initiatedBy ?? null,
+        initiatedBy: initiatedBy ?? null,
       });
 
       const savedRefund = await queryRunner.manager.save(refund);

--- a/src/modules/payments/recurring-payment.entity.ts
+++ b/src/modules/payments/recurring-payment.entity.ts
@@ -1,0 +1,77 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export enum RecurringPaymentInterval {
+  DAILY = 'daily',
+  WEEKLY = 'weekly',
+  MONTHLY = 'monthly',
+}
+
+export enum RecurringPaymentStatus {
+  ACTIVE = 'active',
+  PAUSED = 'paused',
+  CANCELLED = 'cancelled',
+}
+
+@Entity('recurring_payments')
+export class RecurringPayment {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2 })
+  amount: number;
+
+  @Column()
+  currency: string;
+
+  @Column({ type: 'enum', enum: RecurringPaymentInterval })
+  interval: RecurringPaymentInterval;
+
+  @Column({
+    type: 'enum',
+    enum: RecurringPaymentStatus,
+    default: RecurringPaymentStatus.ACTIVE,
+  })
+  status: RecurringPaymentStatus;
+
+  @Column({ nullable: true })
+  description: string | null;
+
+  @Column({ nullable: true })
+  merchantId: string | null;
+
+  @Column({ nullable: true })
+  merchantEmail: string | null;
+
+  @Column({ nullable: true })
+  payerEmail: string | null;
+
+  @Column({ nullable: true, length: 2048 })
+  callbackUrl: string | null;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata: Record<string, string> | null;
+
+  @Column()
+  createdBy: string;
+
+  @Column({ type: 'timestamp' })
+  nextRunAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  lastRunAt: Date | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  cancelledAt: Date | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/payments/recurring-payments.controller.ts
+++ b/src/modules/payments/recurring-payments.controller.ts
@@ -1,0 +1,99 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiParam,
+  ApiNotFoundResponse,
+  ApiConflictResponse,
+} from '@nestjs/swagger';
+import { RecurringPaymentsService } from './recurring-payments.service';
+import { CreateRecurringPaymentDto } from './dto/create-recurring-payment.dto';
+import { RecurringPayment } from './recurring-payment.entity';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@ApiTags('recurring-payments')
+@Controller('v1/recurring-payments')
+@UseGuards(JwtAuthGuard)
+export class RecurringPaymentsController {
+  constructor(private readonly service: RecurringPaymentsService) {}
+
+  @Post()
+  @ApiBearerAuth('bearer')
+  @ApiOperation({
+    summary: 'Create a recurring payment plan',
+    description:
+      'Creates a plan that automatically generates a new payment on the configured interval (daily, weekly, monthly), reusing the normal payment creation and webhook flow for each charge.',
+  })
+  @ApiCreatedResponse({
+    description: 'Recurring payment plan created.',
+    type: RecurringPayment,
+  })
+  create(@Body() dto: CreateRecurringPaymentDto, @Request() req: any) {
+    return this.service.create(dto, req.user.id);
+  }
+
+  @Get()
+  @ApiBearerAuth('bearer')
+  @ApiOperation({ summary: 'List recurring payment plans' })
+  @ApiOkResponse({
+    description: 'Recurring payment plans owned by the authenticated user.',
+    type: [RecurringPayment],
+  })
+  findAll(@Request() req: any) {
+    return this.service.findAll(req.user.id);
+  }
+
+  @Get(':id')
+  @ApiBearerAuth('bearer')
+  @ApiOperation({ summary: 'Get a recurring payment plan' })
+  @ApiParam({ name: 'id', description: 'Recurring payment plan UUID' })
+  @ApiOkResponse({ description: 'Recurring payment plan.', type: RecurringPayment })
+  @ApiNotFoundResponse({ description: 'Plan not found.' })
+  findOne(@Param('id') id: string, @Request() req: any) {
+    return this.service.findOne(id, req.user.id);
+  }
+
+  @Post(':id/pause')
+  @ApiBearerAuth('bearer')
+  @ApiOperation({ summary: 'Pause a recurring payment plan' })
+  @ApiParam({ name: 'id', description: 'Recurring payment plan UUID' })
+  @ApiOkResponse({ description: 'Plan paused.', type: RecurringPayment })
+  @ApiNotFoundResponse({ description: 'Plan not found.' })
+  @ApiConflictResponse({ description: 'Plan is not active.' })
+  pause(@Param('id') id: string, @Request() req: any) {
+    return this.service.pause(id, req.user.id);
+  }
+
+  @Post(':id/resume')
+  @ApiBearerAuth('bearer')
+  @ApiOperation({ summary: 'Resume a paused recurring payment plan' })
+  @ApiParam({ name: 'id', description: 'Recurring payment plan UUID' })
+  @ApiOkResponse({ description: 'Plan resumed.', type: RecurringPayment })
+  @ApiNotFoundResponse({ description: 'Plan not found.' })
+  @ApiConflictResponse({ description: 'Plan is not paused.' })
+  resume(@Param('id') id: string, @Request() req: any) {
+    return this.service.resume(id, req.user.id);
+  }
+
+  @Post(':id/cancel')
+  @ApiBearerAuth('bearer')
+  @ApiOperation({ summary: 'Cancel a recurring payment plan' })
+  @ApiParam({ name: 'id', description: 'Recurring payment plan UUID' })
+  @ApiOkResponse({ description: 'Plan cancelled.', type: RecurringPayment })
+  @ApiNotFoundResponse({ description: 'Plan not found.' })
+  @ApiConflictResponse({ description: 'Plan is already cancelled.' })
+  cancel(@Param('id') id: string, @Request() req: any) {
+    return this.service.cancel(id, req.user.id);
+  }
+}

--- a/src/modules/payments/recurring-payments.service.spec.ts
+++ b/src/modules/payments/recurring-payments.service.spec.ts
@@ -1,0 +1,229 @@
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { RecurringPaymentsService } from './recurring-payments.service';
+import {
+  RecurringPaymentInterval,
+  RecurringPaymentStatus,
+} from './recurring-payment.entity';
+
+describe('RecurringPaymentsService', () => {
+  let service: RecurringPaymentsService;
+  let mockRepository: any;
+  let mockPaymentsService: any;
+  let mockIdempotencyService: any;
+  let mockAppLogger: any;
+
+  beforeEach(() => {
+    mockRepository = {
+      create: jest.fn((data) => ({ ...data })),
+      save: jest.fn((entity) => Promise.resolve(entity)),
+      find: jest.fn(),
+      findOneBy: jest.fn(),
+    };
+
+    mockPaymentsService = {
+      create: jest.fn().mockResolvedValue({ id: 'payment-1' }),
+    };
+
+    mockIdempotencyService = {
+      checkKey: jest.fn().mockResolvedValue(null),
+      storeKey: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockAppLogger = {
+      child: jest.fn().mockReturnValue({ info: jest.fn(), error: jest.fn() }),
+    };
+
+    service = new RecurringPaymentsService(
+      mockRepository,
+      mockPaymentsService,
+      mockIdempotencyService,
+      mockAppLogger,
+    );
+  });
+
+  describe('create', () => {
+    it('creates an active plan owned by the requesting user', async () => {
+      const plan = await service.create(
+        {
+          amount: 29.99,
+          currency: 'USD',
+          interval: RecurringPaymentInterval.MONTHLY,
+        },
+        'user-1',
+      );
+
+      expect(plan.createdBy).toBe('user-1');
+      expect(plan.status).toBe(RecurringPaymentStatus.ACTIVE);
+      expect(plan.nextRunAt).toBeInstanceOf(Date);
+    });
+
+    it('schedules the first run at startAt when provided', async () => {
+      const startAt = '2026-08-01T00:00:00.000Z';
+      const plan = await service.create(
+        {
+          amount: 10,
+          currency: 'USD',
+          interval: RecurringPaymentInterval.WEEKLY,
+          startAt,
+        },
+        'user-1',
+      );
+
+      expect(plan.nextRunAt.toISOString()).toBe(startAt);
+    });
+  });
+
+  describe('pause / resume / cancel', () => {
+    it('pauses an active plan', async () => {
+      mockRepository.findOneBy.mockResolvedValue({
+        id: 'plan-1',
+        createdBy: 'user-1',
+        status: RecurringPaymentStatus.ACTIVE,
+        nextRunAt: new Date(Date.now() + 10000),
+      });
+
+      const result = await service.pause('plan-1', 'user-1');
+      expect(result.status).toBe(RecurringPaymentStatus.PAUSED);
+    });
+
+    it('throws when pausing a non-active plan', async () => {
+      mockRepository.findOneBy.mockResolvedValue({
+        id: 'plan-1',
+        createdBy: 'user-1',
+        status: RecurringPaymentStatus.CANCELLED,
+      });
+
+      await expect(service.pause('plan-1', 'user-1')).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('resumes a paused plan', async () => {
+      mockRepository.findOneBy.mockResolvedValue({
+        id: 'plan-1',
+        createdBy: 'user-1',
+        status: RecurringPaymentStatus.PAUSED,
+        nextRunAt: new Date(Date.now() - 10000),
+      });
+
+      const result = await service.resume('plan-1', 'user-1');
+      expect(result.status).toBe(RecurringPaymentStatus.ACTIVE);
+    });
+
+    it('throws when resuming a non-paused plan', async () => {
+      mockRepository.findOneBy.mockResolvedValue({
+        id: 'plan-1',
+        createdBy: 'user-1',
+        status: RecurringPaymentStatus.ACTIVE,
+      });
+
+      await expect(service.resume('plan-1', 'user-1')).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('cancels an active plan', async () => {
+      mockRepository.findOneBy.mockResolvedValue({
+        id: 'plan-1',
+        createdBy: 'user-1',
+        status: RecurringPaymentStatus.ACTIVE,
+      });
+
+      const result = await service.cancel('plan-1', 'user-1');
+      expect(result.status).toBe(RecurringPaymentStatus.CANCELLED);
+      expect(result.cancelledAt).toBeInstanceOf(Date);
+    });
+
+    it('throws when cancelling an already-cancelled plan', async () => {
+      mockRepository.findOneBy.mockResolvedValue({
+        id: 'plan-1',
+        createdBy: 'user-1',
+        status: RecurringPaymentStatus.CANCELLED,
+      });
+
+      await expect(service.cancel('plan-1', 'user-1')).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('throws NotFoundException for a plan the user does not own', async () => {
+      mockRepository.findOneBy.mockResolvedValue(null);
+
+      await expect(service.pause('missing', 'user-1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('processDuePlans', () => {
+    it('creates a payment for each due plan and advances nextRunAt', async () => {
+      const dueAt = new Date('2026-07-01T00:00:00.000Z');
+      const plan = {
+        id: 'plan-1',
+        amount: 20,
+        currency: 'USD',
+        interval: RecurringPaymentInterval.DAILY,
+        status: RecurringPaymentStatus.ACTIVE,
+        nextRunAt: dueAt,
+        description: null,
+        merchantId: null,
+        merchantEmail: null,
+        payerEmail: null,
+        callbackUrl: null,
+        metadata: null,
+      };
+      mockRepository.find.mockResolvedValue([plan]);
+
+      await service.processDuePlans();
+
+      expect(mockPaymentsService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: 20, currency: 'USD' }),
+      );
+      expect(mockIdempotencyService.storeKey).toHaveBeenCalledWith(
+        `recurring-payment:plan-1:${dueAt.toISOString()}`,
+        expect.anything(),
+        { paymentId: 'payment-1' },
+      );
+      expect(plan.lastRunAt).toEqual(dueAt);
+      expect(plan.nextRunAt.getTime()).toBe(dueAt.getTime() + 24 * 60 * 60 * 1000);
+    });
+
+    it('skips creating a duplicate payment when the run was already processed', async () => {
+      const dueAt = new Date('2026-07-01T00:00:00.000Z');
+      const plan = {
+        id: 'plan-1',
+        amount: 20,
+        currency: 'USD',
+        interval: RecurringPaymentInterval.DAILY,
+        status: RecurringPaymentStatus.ACTIVE,
+        nextRunAt: dueAt,
+      };
+      mockRepository.find.mockResolvedValue([plan]);
+      mockIdempotencyService.checkKey.mockResolvedValue({ paymentId: 'existing-payment' });
+
+      await service.processDuePlans();
+
+      expect(mockPaymentsService.create).not.toHaveBeenCalled();
+      expect(plan.lastRunAt).toEqual(dueAt);
+    });
+
+    it('logs and continues when a charge fails, leaving the plan due for retry', async () => {
+      const dueAt = new Date('2026-07-01T00:00:00.000Z');
+      const plan = {
+        id: 'plan-1',
+        amount: 20,
+        currency: 'USD',
+        interval: RecurringPaymentInterval.DAILY,
+        status: RecurringPaymentStatus.ACTIVE,
+        nextRunAt: dueAt,
+      };
+      mockRepository.find.mockResolvedValue([plan]);
+      mockPaymentsService.create.mockRejectedValue(new Error('boom'));
+
+      await service.processDuePlans();
+
+      expect(plan.nextRunAt).toBe(dueAt);
+      expect(mockRepository.save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/payments/recurring-payments.service.ts
+++ b/src/modules/payments/recurring-payments.service.ts
@@ -1,0 +1,192 @@
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThanOrEqual, Repository } from 'typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import {
+  RecurringPayment,
+  RecurringPaymentInterval,
+  RecurringPaymentStatus,
+} from './recurring-payment.entity';
+import { CreateRecurringPaymentDto } from './dto/create-recurring-payment.dto';
+import { PaymentsService } from './payments.service';
+import { IdempotencyService } from './idempotency.service';
+import { AppLogger } from '../logger/logger.service';
+import { Logger } from 'pino';
+
+@Injectable()
+export class RecurringPaymentsService {
+  private readonly logger: Logger;
+
+  constructor(
+    @InjectRepository(RecurringPayment)
+    private readonly recurringPaymentRepository: Repository<RecurringPayment>,
+    private readonly paymentsService: PaymentsService,
+    private readonly idempotencyService: IdempotencyService,
+    appLogger: AppLogger,
+  ) {
+    this.logger = appLogger.child({ module: RecurringPaymentsService.name });
+  }
+
+  async create(
+    dto: CreateRecurringPaymentDto,
+    createdBy: string,
+  ): Promise<RecurringPayment> {
+    const plan = this.recurringPaymentRepository.create({
+      amount: dto.amount,
+      currency: dto.currency,
+      interval: dto.interval,
+      description: dto.description ?? null,
+      merchantId: dto.merchantId ?? null,
+      merchantEmail: dto.merchantEmail ?? null,
+      payerEmail: dto.payerEmail ?? null,
+      callbackUrl: dto.callbackUrl ?? null,
+      metadata: dto.metadata ?? null,
+      createdBy,
+      status: RecurringPaymentStatus.ACTIVE,
+      nextRunAt: dto.startAt ? new Date(dto.startAt) : new Date(),
+    });
+
+    return this.recurringPaymentRepository.save(plan);
+  }
+
+  async findAll(createdBy: string): Promise<RecurringPayment[]> {
+    return this.recurringPaymentRepository.find({
+      where: { createdBy },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async findOne(id: string, createdBy: string): Promise<RecurringPayment> {
+    const plan = await this.recurringPaymentRepository.findOneBy({
+      id,
+      createdBy,
+    });
+    if (!plan) {
+      throw new NotFoundException(`Recurring payment plan ${id} not found`);
+    }
+    return plan;
+  }
+
+  async pause(id: string, createdBy: string): Promise<RecurringPayment> {
+    const plan = await this.findOne(id, createdBy);
+    if (plan.status !== RecurringPaymentStatus.ACTIVE) {
+      throw new ConflictException(
+        `Cannot pause a plan with status ${plan.status}`,
+      );
+    }
+    plan.status = RecurringPaymentStatus.PAUSED;
+    return this.recurringPaymentRepository.save(plan);
+  }
+
+  async resume(id: string, createdBy: string): Promise<RecurringPayment> {
+    const plan = await this.findOne(id, createdBy);
+    if (plan.status !== RecurringPaymentStatus.PAUSED) {
+      throw new ConflictException(
+        `Cannot resume a plan with status ${plan.status}`,
+      );
+    }
+    plan.status = RecurringPaymentStatus.ACTIVE;
+    if (plan.nextRunAt.getTime() < Date.now()) {
+      plan.nextRunAt = new Date();
+    }
+    return this.recurringPaymentRepository.save(plan);
+  }
+
+  async cancel(id: string, createdBy: string): Promise<RecurringPayment> {
+    const plan = await this.findOne(id, createdBy);
+    if (plan.status === RecurringPaymentStatus.CANCELLED) {
+      throw new ConflictException('Plan is already cancelled');
+    }
+    plan.status = RecurringPaymentStatus.CANCELLED;
+    plan.cancelledAt = new Date();
+    return this.recurringPaymentRepository.save(plan);
+  }
+
+  private computeNextRunAt(
+    interval: RecurringPaymentInterval,
+    from: Date,
+  ): Date {
+    const next = new Date(from);
+    switch (interval) {
+      case RecurringPaymentInterval.DAILY:
+        next.setDate(next.getDate() + 1);
+        break;
+      case RecurringPaymentInterval.WEEKLY:
+        next.setDate(next.getDate() + 7);
+        break;
+      case RecurringPaymentInterval.MONTHLY:
+        next.setMonth(next.getMonth() + 1);
+        break;
+    }
+    return next;
+  }
+
+  /**
+   * Executes due recurring plans, creating a normal payment for each one via
+   * the existing PaymentsService (reusing its fee/split/webhook lifecycle).
+   * Guarded by an idempotency key per scheduled run to avoid double-charging
+   * if the sweep overlaps or is retried.
+   */
+  @Cron(CronExpression.EVERY_MINUTE)
+  async processDuePlans(): Promise<void> {
+    const duePlans = await this.recurringPaymentRepository.find({
+      where: {
+        status: RecurringPaymentStatus.ACTIVE,
+        nextRunAt: LessThanOrEqual(new Date()),
+      },
+    });
+
+    for (const plan of duePlans) {
+      await this.executePlan(plan);
+    }
+  }
+
+  private async executePlan(plan: RecurringPayment): Promise<void> {
+    const scheduledFor = plan.nextRunAt;
+    const idempotencyKey = `recurring-payment:${plan.id}:${scheduledFor.toISOString()}`;
+
+    try {
+      const requestBody = {
+        planId: plan.id,
+        scheduledFor: scheduledFor.toISOString(),
+      };
+      const existing = await this.idempotencyService.checkKey(
+        idempotencyKey,
+        requestBody,
+      );
+
+      if (!existing) {
+        const payment = await this.paymentsService.create({
+          amount: plan.amount,
+          currency: plan.currency,
+          description: plan.description ?? undefined,
+          merchantId: plan.merchantId ?? undefined,
+          merchantEmail: plan.merchantEmail ?? undefined,
+          payerEmail: plan.payerEmail ?? undefined,
+          callbackUrl: plan.callbackUrl ?? undefined,
+          metadata: plan.metadata ?? undefined,
+        });
+        await this.idempotencyService.storeKey(idempotencyKey, requestBody, {
+          paymentId: payment.id,
+        });
+        this.logger.info(
+          { planId: plan.id, paymentId: payment.id },
+          'Recurring payment charge created',
+        );
+      }
+
+      plan.lastRunAt = scheduledFor;
+      plan.nextRunAt = this.computeNextRunAt(plan.interval, scheduledFor);
+      await this.recurringPaymentRepository.save(plan);
+    } catch (error) {
+      this.logger.error(
+        { planId: plan.id, error: error instanceof Error ? error.message : error },
+        'Recurring payment charge failed',
+      );
+    }
+  }
+}

--- a/src/modules/payments/refund.entity.ts
+++ b/src/modules/payments/refund.entity.ts
@@ -33,7 +33,7 @@ export class Refund {
 
   @Column({ nullable: true })
   @ApiPropertyOptional({ description: 'User ID or system actor that initiated the refund' })
-  initiatedBy: string;
+  initiatedBy: string | null;
 
   @CreateDateColumn()
   @ApiProperty()

--- a/src/modules/payments/refund.service.spec.ts
+++ b/src/modules/payments/refund.service.spec.ts
@@ -8,8 +8,10 @@ import { AppLogger } from '../logger/logger.service';
 import { IdempotencyService } from './idempotency.service';
 import { EmailNotificationService } from '../notifications/email-notification.service';
 import { PaymentSplit } from './payment-split.entity';
+import { MerchantFeeConfig } from './merchant-fee-config.entity';
 import { WebhooksService } from '../webhooks/webhooks.service';
 import { StellarService } from '../stellar/stellar.service';
+import { PaymentSseService } from './payment-sse.service';
 import { ConfigService } from '@nestjs/config';
 import {
   NotFoundException,
@@ -90,6 +92,14 @@ describe('PaymentsService - Refunds', () => {
           useValue: { create: jest.fn(), save: jest.fn(), find: jest.fn(), findOneBy: jest.fn() },
         },
         {
+          provide: getRepositoryToken(MerchantFeeConfig),
+          useValue: { create: jest.fn(), save: jest.fn(), find: jest.fn(), findOneBy: jest.fn() },
+        },
+        {
+          provide: PaymentSseService,
+          useValue: { emit: jest.fn() },
+        },
+        {
           provide: WebhooksService,
           useValue: { dispatchEventToMerchant: jest.fn().mockResolvedValue(undefined) },
         },
@@ -134,6 +144,66 @@ describe('PaymentsService - Refunds', () => {
       expect(result.payment.status).toBe(PaymentStatus.REFUNDED);
       expect(result.payment.refundedAmount).toBe(100);
       expect(result.refund.amount).toBe(100);
+    });
+
+    it('should record the authenticated actor as initiatedBy on the refund', async () => {
+      const payment = {
+        id: '123',
+        amount: 100,
+        refundedAmount: 0,
+        status: PaymentStatus.COMPLETED,
+      };
+
+      mockQueryRunner.manager.findOneBy.mockResolvedValue(payment);
+      mockQueryRunner.manager.create.mockReturnValue({
+        paymentId: '123',
+        amount: 100,
+        initiatedBy: 'admin-user-1',
+      });
+      mockQueryRunner.manager.save
+        .mockResolvedValueOnce({ id: 'refund-1', amount: 100, initiatedBy: 'admin-user-1' })
+        .mockResolvedValueOnce({
+          ...payment,
+          refundedAmount: 100,
+          status: PaymentStatus.REFUNDED,
+        });
+
+      const result = await service.refund('123', {}, 'admin-user-1');
+
+      expect(mockQueryRunner.manager.create).toHaveBeenCalledWith(
+        Refund,
+        expect.objectContaining({ initiatedBy: 'admin-user-1' }),
+      );
+      expect(result.refund.initiatedBy).toBe('admin-user-1');
+    });
+
+    it('should record initiatedBy as null when no actor is authenticated', async () => {
+      const payment = {
+        id: '123',
+        amount: 100,
+        refundedAmount: 0,
+        status: PaymentStatus.COMPLETED,
+      };
+
+      mockQueryRunner.manager.findOneBy.mockResolvedValue(payment);
+      mockQueryRunner.manager.create.mockReturnValue({
+        paymentId: '123',
+        amount: 100,
+      });
+      mockQueryRunner.manager.save
+        .mockResolvedValueOnce({ id: 'refund-1', amount: 100 })
+        .mockResolvedValueOnce({
+          ...payment,
+          refundedAmount: 100,
+          status: PaymentStatus.REFUNDED,
+        });
+
+      await service.refund('123', {});
+
+      expect(mockQueryRunner.manager.create).toHaveBeenCalledWith(
+        Refund,
+        expect.objectContaining({ initiatedBy: null }),
+      );
     });
 
     it('should process partial refund and set status to PARTIALLY_REFUNDED', async () => {

--- a/src/modules/stellar/stellar.controller.ts
+++ b/src/modules/stellar/stellar.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Delete,
   Body,
   Param,
   Query,
@@ -19,6 +20,7 @@ import {
   ApiOkResponse,
   ApiNotFoundResponse,
   ApiBadRequestResponse,
+  ApiNoContentResponse,
 } from '@nestjs/swagger';
 import { StellarService } from './stellar.service';
 import { SignTransactionDto } from './dto/sign-transaction.dto';

--- a/src/modules/throttler/merchant-throttler.guard.rate-limit-override.spec.ts
+++ b/src/modules/throttler/merchant-throttler.guard.rate-limit-override.spec.ts
@@ -1,0 +1,118 @@
+import { Reflector } from '@nestjs/core';
+import { MerchantThrottlerGuard } from './merchant-throttler.guard';
+
+describe('MerchantThrottlerGuard - rate limit overrides', () => {
+  let guard: MerchantThrottlerGuard;
+  let mockUsersService: { findOne: jest.Mock };
+  let mockStorage: { increment: jest.Mock };
+
+  const options = {
+    throttlers: [{ name: 'default', ttl: 60000, limit: 100 }],
+  };
+
+  beforeEach(async () => {
+    mockUsersService = { findOne: jest.fn() };
+    mockStorage = {
+      increment: jest.fn().mockResolvedValue({
+        totalHits: 1,
+        timeToExpire: 60,
+        isBlocked: false,
+        timeToBlockExpire: 0,
+      }),
+    };
+
+    guard = new MerchantThrottlerGuard(
+      options as any,
+      mockStorage as any,
+      new Reflector(),
+      mockUsersService as any,
+    );
+    await (guard as any).onModuleInit();
+  });
+
+  const resolveOverride = (req: any) =>
+    (guard as any).resolveRateLimitOverride(req);
+
+  it('prefers the API key override over any user-level config', async () => {
+    mockUsersService.findOne.mockResolvedValue({
+      rateLimitEnabled: true,
+      rateLimitLimit: 10,
+      rateLimitTtl: 1000,
+    });
+
+    const override = await resolveOverride({
+      apiKey: { userId: 'user-1', rateLimitLimit: 500, rateLimitTtl: 5000 },
+    });
+
+    expect(override).toEqual({ limit: 500, ttl: 5000 });
+    expect(mockUsersService.findOne).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the default throttler ttl when the API key sets only a limit', async () => {
+    const override = await resolveOverride({
+      apiKey: { userId: 'user-1', rateLimitLimit: 500, rateLimitTtl: null },
+    });
+
+    expect(override).toEqual({ limit: 500, ttl: 60000 });
+  });
+
+  it('falls back to the per-user override when no API key override is set', async () => {
+    mockUsersService.findOne.mockResolvedValue({
+      rateLimitEnabled: true,
+      rateLimitLimit: 10,
+      rateLimitTtl: 1000,
+    });
+
+    const override = await resolveOverride({ user: { id: 'user-1' } });
+
+    expect(override).toEqual({ limit: 10, ttl: 1000 });
+    expect(mockUsersService.findOne).toHaveBeenCalledWith('user-1');
+  });
+
+  it('returns null when neither an API key nor a user override applies', async () => {
+    mockUsersService.findOne.mockResolvedValue({ rateLimitEnabled: false });
+
+    const override = await resolveOverride({ user: { id: 'user-1' } });
+
+    expect(override).toBeNull();
+  });
+
+  it('returns null for anonymous requests without hitting the user lookup', async () => {
+    const override = await resolveOverride({});
+
+    expect(override).toBeNull();
+    expect(mockUsersService.findOne).not.toHaveBeenCalled();
+  });
+
+  it('only overrides the default throttler bucket, not named buckets like auth', async () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          apiKey: { userId: 'user-1', rateLimitLimit: 500, rateLimitTtl: 5000 },
+        }),
+        getResponse: () => ({ header: jest.fn() }),
+      }),
+    } as any;
+
+    const superHandleRequest = jest.spyOn(
+      Object.getPrototypeOf(Object.getPrototypeOf(guard)),
+      'handleRequest',
+    );
+
+    await (guard as any).handleRequest({
+      context,
+      limit: 5,
+      ttl: 900000,
+      throttler: { name: 'auth' },
+      blockDuration: 900000,
+      getTracker: async () => 'tracker',
+      generateKey: () => 'key',
+    });
+
+    expect(superHandleRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 5, ttl: 900000 }),
+    );
+
+    superHandleRequest.mockRestore();
+  });
+});

--- a/src/modules/throttler/merchant-throttler.guard.spec.ts
+++ b/src/modules/throttler/merchant-throttler.guard.spec.ts
@@ -39,9 +39,7 @@ describe('MerchantThrottlerGuard', () => {
 
     // Create mock storage
     mockStorage = {
-      get: jest.fn(),
-      set: jest.fn(),
-      add: jest.fn(),
+      increment: jest.fn(),
     };
 
     const moduleFixture: TestingModule = await Test.createTestingModule({

--- a/src/modules/throttler/merchant-throttler.guard.ts
+++ b/src/modules/throttler/merchant-throttler.guard.ts
@@ -1,89 +1,84 @@
+import { Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import {
-  CanActivate,
-  ExecutionContext,
-  Injectable,
-} from '@nestjs/common';
-import { ThrottlerGuard } from '@nestjs/throttler';
-import { ThrottlerStorage } from '@nestjs/throttler/dist/throttler-storage.interface';
+  InjectThrottlerOptions,
+  InjectThrottlerStorage,
+  ThrottlerGuard,
+} from '@nestjs/throttler';
+import type {
+  ThrottlerModuleOptions,
+  ThrottlerRequest,
+  ThrottlerStorage,
+} from '@nestjs/throttler';
 import { UsersService } from '../users/users.service';
+
+interface RateLimitOverride {
+  limit: number;
+  ttl: number;
+}
 
 @Injectable()
 export class MerchantThrottlerGuard extends ThrottlerGuard {
-  private readonly storage: ThrottlerStorage;
-
   constructor(
-    storage: ThrottlerStorage,
+    @InjectThrottlerOptions() options: ThrottlerModuleOptions,
+    @InjectThrottlerStorage() storageService: ThrottlerStorage,
+    reflector: Reflector,
     private readonly usersService: UsersService,
   ) {
-    super(storage);
-    this.storage = storage;
+    super(options, storageService, reflector);
   }
 
-  async canActivate(context: ExecutionContext): Promise<boolean> {
-    const request = context.switchToHttp().getRequest();
-    
-    // Extract merchant/user identifier from request
-    // Priority: API key user > JWT user
-    let userId: string | undefined;
-    
-    if (request.apiKey?.userId) {
-      userId = request.apiKey.userId;
-    } else if (request.user?.id) {
-      userId = request.user.id;
-    }
-
-    // If we have a user, check for custom rate limits
-    if (userId) {
-      try {
-        const user = await this.usersService.findOne(userId);
-        
-        // If user has custom rate limits enabled, use them
-        if (user?.rateLimitEnabled && user.rateLimitLimit && user.rateLimitTtl) {
-          // Store the merchant-specific limits in the request for later use
-          request.merchantRateLimit = {
-            limit: user.rateLimitLimit,
-            ttl: user.rateLimitTtl,
-          };
-        }
-      } catch (error) {
-        // If we can't fetch user config, fall back to global defaults
-        // Log but don't fail the request
-        console.warn(`Failed to fetch rate limit config for user ${userId}:`, error);
+  protected async handleRequest(
+    requestProps: ThrottlerRequest,
+  ): Promise<boolean> {
+    // Overrides only apply to the general-purpose 'default' throttler bucket;
+    // dedicated buckets (auth, webhook, bulk) keep their fixed limits.
+    if (requestProps.throttler.name === 'default') {
+      const { req } = this.getRequestResponse(requestProps.context);
+      const override = await this.resolveRateLimitOverride(req);
+      if (override) {
+        return super.handleRequest({
+          ...requestProps,
+          limit: override.limit,
+          ttl: override.ttl,
+        });
       }
     }
 
-    // Proceed with standard throttler guard logic
-    return super.canActivate(context);
+    return super.handleRequest(requestProps);
   }
 
-  protected async resolveRequestTimeout(
-    context: ExecutionContext,
-    handler: Function,
-  ): Promise<number> {
-    const request = context.switchToHttp().getRequest();
-    
-    // If merchant has custom rate limits, use their TTL
-    if (request.merchantRateLimit?.ttl) {
-      return request.merchantRateLimit.ttl;
-    }
-    
-    // Otherwise use default from throttler config
-    return super.resolveRequestTimeout(context, handler);
-  }
-
-  protected async getTracker(
+  private async resolveRateLimitOverride(
     req: any,
-    limiter: { ttl: number; limit: number },
-  ): Promise<{ totalHits: number; resetTime: Date }> {
-    // If merchant has custom rate limits, use their limit
-    if (req.merchantRateLimit?.limit) {
-      const customLimiter = {
-        ttl: req.merchantRateLimit.ttl || limiter.ttl,
-        limit: req.merchantRateLimit.limit,
+  ): Promise<RateLimitOverride | null> {
+    // A per-API-key rate limit override takes precedence over everything else.
+    if (req.apiKey?.rateLimitLimit) {
+      return {
+        limit: req.apiKey.rateLimitLimit,
+        ttl: req.apiKey.rateLimitTtl || this.getDefaultTtl(),
       };
-      return super.getTracker(req, customLimiter);
     }
-    
-    return super.getTracker(req, limiter);
+
+    const userId = req.apiKey?.userId ?? req.user?.id;
+    if (!userId) {
+      return null;
+    }
+
+    try {
+      const user = await this.usersService.findOne(userId);
+      if (user?.rateLimitEnabled && user.rateLimitLimit && user.rateLimitTtl) {
+        return { limit: user.rateLimitLimit, ttl: user.rateLimitTtl };
+      }
+    } catch (error) {
+      // If we can't fetch user config, fall back to global defaults
+      console.warn(`Failed to fetch rate limit config for user ${userId}:`, error);
+    }
+
+    return null;
+  }
+
+  private getDefaultTtl(): number {
+    const defaultThrottler = this.throttlers.find((t) => t.name === 'default');
+    return Number(defaultThrottler?.ttl ?? 60000);
   }
 }

--- a/src/modules/throttler/throttler.config.module.ts
+++ b/src/modules/throttler/throttler.config.module.ts
@@ -31,9 +31,10 @@ import { UsersModule } from '../users/users.module';
     UsersModule,
   ],
   providers: [
+    MerchantThrottlerGuard,
     {
       provide: APP_GUARD,
-      useClass: MerchantThrottlerGuard,
+      useExisting: MerchantThrottlerGuard,
     },
   ],
   exports: [MerchantThrottlerGuard],

--- a/test/refunds.e2e-spec.ts
+++ b/test/refunds.e2e-spec.ts
@@ -1,17 +1,28 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
+import request from 'supertest';
 import { AppModule } from '../src/app.module';
+import { JwtAuthGuard } from '../src/modules/auth/guards/jwt-auth.guard';
 import { DataSource } from 'typeorm';
 
 describe('Refunds (e2e)', () => {
   let app: INestApplication;
   let dataSource: DataSource;
+  const authToken = 'test-token';
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
-    }).compile();
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({
+        canActivate: (context: any) => {
+          const request = context.switchToHttp().getRequest();
+          request.user = { id: 'test-admin-id', email: 'admin@example.com' };
+          return true;
+        },
+      })
+      .compile();
 
     app = moduleFixture.createNestApplication();
     await app.init();
@@ -42,12 +53,14 @@ describe('Refunds (e2e)', () => {
 
     const refundResponse = await request(app.getHttpServer())
       .post(`/payments/${payment.body.id}/refund`)
+      .set('Authorization', `Bearer ${authToken}`)
       .send({})
       .expect(201);
 
     expect(refundResponse.body.payment.status).toBe('REFUNDED');
     expect(refundResponse.body.payment.refundedAmount).toBe('100.00');
     expect(refundResponse.body.refund.amount).toBe('100.00');
+    expect(refundResponse.body.refund.initiatedBy).toBe('test-admin-id');
   });
 
   it('should process partial refund', async () => {
@@ -63,6 +76,7 @@ describe('Refunds (e2e)', () => {
 
     const refundResponse = await request(app.getHttpServer())
       .post(`/payments/${payment.body.id}/refund`)
+      .set('Authorization', `Bearer ${authToken}`)
       .send({ amount: 50, reason: 'Partial refund requested' })
       .expect(201);
 
@@ -79,6 +93,7 @@ describe('Refunds (e2e)', () => {
 
     return request(app.getHttpServer())
       .post(`/payments/${payment.body.id}/refund`)
+      .set('Authorization', `Bearer ${authToken}`)
       .send({})
       .expect(409)
       .expect((res) => {
@@ -99,11 +114,13 @@ describe('Refunds (e2e)', () => {
 
     await request(app.getHttpServer())
       .post(`/payments/${payment.body.id}/refund`)
+      .set('Authorization', `Bearer ${authToken}`)
       .send({})
       .expect(201);
 
     return request(app.getHttpServer())
       .post(`/payments/${payment.body.id}/refund`)
+      .set('Authorization', `Bearer ${authToken}`)
       .send({})
       .expect(409)
       .expect((res) => {
@@ -124,11 +141,13 @@ describe('Refunds (e2e)', () => {
 
     await request(app.getHttpServer())
       .post(`/payments/${payment.body.id}/refund`)
+      .set('Authorization', `Bearer ${authToken}`)
       .send({ amount: 60 })
       .expect(201);
 
     return request(app.getHttpServer())
       .post(`/payments/${payment.body.id}/refund`)
+      .set('Authorization', `Bearer ${authToken}`)
       .send({ amount: 50 })
       .expect(409)
       .expect((res) => {
@@ -149,11 +168,13 @@ describe('Refunds (e2e)', () => {
 
     await request(app.getHttpServer())
       .post(`/payments/${payment.body.id}/refund`)
+      .set('Authorization', `Bearer ${authToken}`)
       .send({ amount: 30 })
       .expect(201);
 
     await request(app.getHttpServer())
       .post(`/payments/${payment.body.id}/refund`)
+      .set('Authorization', `Bearer ${authToken}`)
       .send({ amount: 20 })
       .expect(201);
 
@@ -164,5 +185,6 @@ describe('Refunds (e2e)', () => {
     expect(getResponse.body.refunds).toHaveLength(2);
     expect(getResponse.body.refunds[0].amount).toBe('20.00');
     expect(getResponse.body.refunds[1].amount).toBe('30.00');
+    expect(getResponse.body.refunds[0].initiatedBy).toBe('test-admin-id');
   });
 });


### PR DESCRIPTION


Summary
Implements four feature requests:

closes #222 — Track the initiating actor on each refund: POST /payments/:id/refund now requires authentication (JwtAuthGuard) and derives initiatedBy from the authenticated user instead of trusting a client-supplied field (removed from RefundPaymentDto to close the spoofing hole).
closes #223 — Pagination and sort on GET /payments: verified already implemented (page/limit/sortBy/order, offset + cursor pagination, total/page/limit metadata, sort by createdAt/amount/status); fixed a couple of latent bugs in the surrounding DTO/tests.
closes #224 — Recurring/scheduled payments: new RecurringPayment resource (v1/recurring-payments) supporting create/pause/resume/cancel, with a per-minute @Cron sweep that charges due plans through the existing PaymentsService.create() (reusing fee/split/webhook lifecycle) and guards each scheduled run with IdempotencyService to prevent double-charging.
closes #225 — Per-API-key rate limit overrides: ApiKey entity gained optional rateLimitLimit/rateLimitTtl; MerchantThrottlerGuard now applies the API key's override (highest priority) before falling back to the existing per-user override, then the global default. Only the default throttle bucket is overridden — auth/bulk/webhook buckets keep fixed limits.
Pre-existing bugs fixed along the way
Several of these files didn't compile/boot at all, which blocked implementing and verifying the above, so they're included:

payments.module.ts referenced non-existent PaymentsAnalyticsController/Service and missing Dispute/NotificationsModule imports.
api-keys.service.ts / api-keys.controller.ts had a duplicate update() method (and duplicate @Patch(':id') route).
MerchantThrottlerGuard was written against an old @nestjs/throttler API incompatible with the installed v6 (broken constructor, resolveRequestTimeout/getTracker no longer exist) — rewritten against the real v6 handleRequest hook; ThrottlerConfigModule also failed to export it correctly.
stellar.controller.ts and auth.controller.ts used @Delete/@ApiNoContentResponse/@Patch without importing them.
Payment.callbackUrl had no explicit TypeORM column type, which crashes DataSource.initialize() against Postgres.
Several spec files (refund.service.spec.ts, payments.service.spec.ts) were missing providers/imports and failed to even construct their TestingModule.
Test plan
 refund.service.spec.ts, payments.service.spec.ts, recurring-payments.service.spec.ts, merchant-throttler.guard.*.spec.ts — unit tests pass
 test/refunds.e2e-spec.ts updated for the new auth requirement and initiatedBy field
 npm run build — pre-existing TS error count reduced (56 → ~46), zero new errors from this change
 Full e2e suite (npm run test:e2e) — blocked by unrelated pre-existing issues (otplib/jest ESM transform); not exercised here