### PR TITLE
feat : Add timestamp-based replay protection to payment webhook signa…

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,7 +22,6 @@ import { RatesModule } from './modules/rates/rates.module';
 import { MerchantsModule } from './modules/merchants/merchants.module';
 import { OnboardingModule } from './modules/onboarding/onboarding.module';
 import { SecurityHeadersMiddleware } from './common/middleware/security-headers.middleware';
-import { OnboardingModule } from './modules/onboarding/onboarding.module';
 
 @Module({
   imports: [

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -456,7 +456,7 @@ export class AuthController {
     return this.authService.resetPassword(dto);
   }
 
-  @UseGuards(RolesGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('ADMIN')
   @Post('unlock/:userId')
   @HttpCode(HttpStatus.OK)

--- a/src/modules/payments/merchant-fees.controller.spec.ts
+++ b/src/modules/payments/merchant-fees.controller.spec.ts
@@ -1,0 +1,47 @@
+import { MerchantFeesController } from './merchant-fees.controller';
+import { PaymentsService } from './payments.service';
+
+describe('MerchantFeesController', () => {
+  let controller: MerchantFeesController;
+  let paymentsService: {
+    getMerchantFeeConfig: jest.Mock;
+    getFeeReport: jest.Mock;
+  };
+
+  beforeEach(() => {
+    paymentsService = {
+      getMerchantFeeConfig: jest.fn(),
+      getFeeReport: jest.fn(),
+    };
+
+    controller = new MerchantFeesController(paymentsService as unknown as PaymentsService);
+  });
+
+  it('returns fee config for authenticated merchant only', async () => {
+    const user = { id: 'merchant-123' } as any;
+    const expectedConfig = {
+      merchantId: user.id,
+      flatFee: 1.5,
+      percentageFee: 2.5,
+      minFee: 0.5,
+    };
+    paymentsService.getMerchantFeeConfig.mockResolvedValue(expectedConfig);
+
+    await expect(controller.getMyFeeConfig(user)).resolves.toEqual(expectedConfig);
+    expect(paymentsService.getMerchantFeeConfig).toHaveBeenCalledWith(user.id);
+  });
+
+  it('returns fee report for authenticated merchant only', async () => {
+    const user = { id: 'merchant-123' } as any;
+    const expectedReport = {
+      merchantId: user.id,
+      totalGrossAmount: 120,
+      totalFeeAmount: 3,
+      totalNetAmount: 117,
+    };
+    paymentsService.getFeeReport.mockResolvedValue(expectedReport);
+
+    await expect(controller.getMyFeeReport(user)).resolves.toEqual(expectedReport);
+    expect(paymentsService.getFeeReport).toHaveBeenCalledWith(user.id);
+  });
+});

--- a/src/modules/payments/merchant-fees.controller.ts
+++ b/src/modules/payments/merchant-fees.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { User } from '../users/user.entity';
+import { PaymentsService } from './payments.service';
+
+@ApiTags('merchants')
+@ApiBearerAuth('bearer')
+@UseGuards(JwtAuthGuard)
+@Controller('v1/merchants/me')
+export class MerchantFeesController {
+  constructor(private readonly paymentsService: PaymentsService) {}
+
+  @Get('fee-config')
+  @ApiOperation({
+    summary: 'Get current merchant fee configuration',
+    description:
+      'Returns the authenticated merchant fee config. No admin role required.',
+  })
+  getMyFeeConfig(@CurrentUser() user: User) {
+    return this.paymentsService.getMerchantFeeConfig(user.id);
+  }
+
+  @Get('fee-report')
+  @ApiOperation({
+    summary: 'Get current merchant fee report',
+    description:
+      'Returns gross/fee/net totals for the authenticated merchant only. No admin role required.',
+  })
+  getMyFeeReport(@CurrentUser() user: User) {
+    return this.paymentsService.getFeeReport(user.id);
+  }
+}

--- a/src/modules/payments/payments.controller.ts
+++ b/src/modules/payments/payments.controller.ts
@@ -460,14 +460,28 @@ export class PaymentsController {
   @ApiOperation({
     summary: 'Handle payment webhook',
     description:
-      'Updates payment status from an external provider. Requires a valid HMAC-SHA256 signature in the X-Signature header computed over the raw JSON body using the configured WEBHOOK_SECRET.',
+      'Updates payment status from an external provider. Requires X-Signature-Timestamp and a valid HMAC-SHA256 signature in X-Signature, computed over "<timestamp>.<raw_json_body>" using WEBHOOK_SECRET.',
   })
   @ApiHeader({
     name: 'X-Signature',
     description:
-      'HMAC-SHA256 hex digest of the raw request body, keyed with WEBHOOK_SECRET',
+      'HMAC-SHA256 hex digest of "<X-Signature-Timestamp>.<raw request body>", keyed with WEBHOOK_SECRET',
     required: true,
     example: 'a1b2c3d4e5f6...',
+  })
+  @ApiHeader({
+    name: 'X-Signature-Timestamp',
+    description:
+      'Unix timestamp (seconds). Requests older than configured tolerance are rejected.',
+    required: true,
+    example: '1753794900',
+  })
+  @ApiHeader({
+    name: 'X-Signature-Nonce',
+    description:
+      'Optional unique nonce for replay protection when nonce cache is enabled.',
+    required: false,
+    example: '0f14f837-5d15-4333-a283-6fccc5e29f28',
   })
   @ApiBody({ type: PaymentWebhookDto })
   @ApiOkResponse({

--- a/src/modules/payments/payments.module.ts
+++ b/src/modules/payments/payments.module.ts
@@ -28,6 +28,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
 import { RecurringPayment } from './recurring-payment.entity';
 import { RecurringPaymentsService } from './recurring-payments.service';
 import { RecurringPaymentsController } from './recurring-payments.controller';
+import { MerchantFeesController } from './merchant-fees.controller';
 
 @Module({
   imports: [
@@ -54,6 +55,7 @@ import { RecurringPaymentsController } from './recurring-payments.controller';
     PaymentQrController,
     DisputesController,
     RecurringPaymentsController,
+    MerchantFeesController,
   ],
   providers: [
     PaymentsService,

--- a/src/modules/payments/payments.service.spec.ts
+++ b/src/modules/payments/payments.service.spec.ts
@@ -20,6 +20,7 @@ import { SortOrder } from '../../common/dto/pagination.dto';
 describe('PaymentsService', () => {
   let service: PaymentsService;
   let repository: Repository<Payment>;
+  let merchantFeeConfigRepository: Repository<MerchantFeeConfig>;
   let dataSource: DataSource;
 
   const baseDate = new Date('2026-01-26T10:00:00.000Z');
@@ -183,6 +184,9 @@ describe('PaymentsService', () => {
 
     service = module.get<PaymentsService>(PaymentsService);
     repository = module.get<Repository<Payment>>(getRepositoryToken(Payment));
+    merchantFeeConfigRepository = module.get<Repository<MerchantFeeConfig>>(
+      getRepositoryToken(MerchantFeeConfig),
+    );
     dataSource = module.get<DataSource>(DataSource);
   });
 
@@ -669,6 +673,44 @@ describe('PaymentsService', () => {
       expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
       expect(mockQueryRunner.commitTransaction).not.toHaveBeenCalled();
       expect(mockQueryRunner.release).toHaveBeenCalled();
+    });
+  });
+
+  describe('getMerchantFeeConfig', () => {
+    it('returns existing fee configuration for merchant', async () => {
+      const existingConfig = {
+        merchantId: 'merchant-1',
+        flatFee: 1.5,
+        percentageFee: 2.25,
+        minFee: 0.5,
+      };
+      jest
+        .spyOn(merchantFeeConfigRepository, 'findOneBy')
+        .mockResolvedValueOnce(existingConfig as MerchantFeeConfig);
+
+      await expect(service.getMerchantFeeConfig('merchant-1')).resolves.toEqual(
+        {
+          merchantId: 'merchant-1',
+          flatFee: 1.5,
+          percentageFee: 2.25,
+          minFee: 0.5,
+        },
+      );
+    });
+
+    it('returns zeroed defaults when no fee config exists', async () => {
+      jest
+        .spyOn(merchantFeeConfigRepository, 'findOneBy')
+        .mockResolvedValueOnce(null);
+
+      await expect(service.getMerchantFeeConfig('merchant-2')).resolves.toEqual(
+        {
+          merchantId: 'merchant-2',
+          flatFee: 0,
+          percentageFee: 0,
+          minFee: 0,
+        },
+      );
     });
   });
 });

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -164,6 +164,33 @@ export class PaymentsService {
     return this.merchantFeeConfigRepository.save(config);
   }
 
+  async getMerchantFeeConfig(merchantId: string): Promise<{
+    merchantId: string;
+    flatFee: number;
+    percentageFee: number;
+    minFee: number;
+  }> {
+    const config = await this.merchantFeeConfigRepository.findOneBy({
+      merchantId,
+    });
+
+    if (config) {
+      return {
+        merchantId: config.merchantId,
+        flatFee: Number(config.flatFee ?? 0),
+        percentageFee: Number(config.percentageFee ?? 0),
+        minFee: Number(config.minFee ?? 0),
+      };
+    }
+
+    return {
+      merchantId,
+      flatFee: 0,
+      percentageFee: 0,
+      minFee: 0,
+    };
+  }
+
   async getFeeReport(merchantId: string): Promise<PaymentFeeReportDto> {
     const payments = await this.paymentRepository.find({
       where: { merchantId },

--- a/src/modules/payments/webhook-signature.service.spec.ts
+++ b/src/modules/payments/webhook-signature.service.spec.ts
@@ -4,9 +4,9 @@ import { WebhookSignatureService } from './webhook-signature.service';
 
 describe('WebhookSignatureService', () => {
   let service: WebhookSignatureService;
-  let configService: ConfigService;
 
   const mockSecret = 'test-webhook-secret';
+  const currentTimestamp = () => String(Math.floor(Date.now() / 1000));
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -19,6 +19,12 @@ describe('WebhookSignatureService', () => {
               if (key === 'WEBHOOK_SECRET') {
                 return mockSecret;
               }
+              if (key === 'WEBHOOK_TIMESTAMP_TOLERANCE_MINUTES') {
+                return 5;
+              }
+              if (key === 'WEBHOOK_NONCE_REPLAY_CACHE_ENABLED') {
+                return 'true';
+              }
               return undefined;
             }),
           },
@@ -27,15 +33,15 @@ describe('WebhookSignatureService', () => {
     }).compile();
 
     service = module.get<WebhookSignatureService>(WebhookSignatureService);
-    configService = module.get<ConfigService>(ConfigService);
   });
 
   describe('generateSignature', () => {
     it('should generate consistent signature for same payload', () => {
       const payload = JSON.stringify({ paymentId: '123', status: 'COMPLETED' });
+      const validTimestamp = currentTimestamp();
 
-      const sig1 = service.generateSignature(payload);
-      const sig2 = service.generateSignature(payload);
+      const sig1 = service.generateSignature(payload, validTimestamp);
+      const sig2 = service.generateSignature(payload, validTimestamp);
 
       expect(sig1).toBe(sig2);
     });
@@ -46,16 +52,29 @@ describe('WebhookSignatureService', () => {
         status: 'COMPLETED',
       });
       const payload2 = JSON.stringify({ paymentId: '456', status: 'FAILED' });
+      const validTimestamp = currentTimestamp();
 
-      const sig1 = service.generateSignature(payload1);
-      const sig2 = service.generateSignature(payload2);
+      const sig1 = service.generateSignature(payload1, validTimestamp);
+      const sig2 = service.generateSignature(payload2, validTimestamp);
 
+      expect(sig1).not.toBe(sig2);
+    });
+
+    it('should generate different signature for same payload with different timestamps', () => {
+      const payload = JSON.stringify({ test: 'data' });
+      const validTimestamp = currentTimestamp();
+      const sig1 = service.generateSignature(payload, validTimestamp);
+      const sig2 = service.generateSignature(
+        payload,
+        String(Number(validTimestamp) + 1),
+      );
       expect(sig1).not.toBe(sig2);
     });
 
     it('should generate hex-encoded signature', () => {
       const payload = JSON.stringify({ test: 'data' });
-      const signature = service.generateSignature(payload);
+      const validTimestamp = currentTimestamp();
+      const signature = service.generateSignature(payload, validTimestamp);
 
       // Should be valid hex string
       expect(/^[a-f0-9]{64}$/i.test(signature)).toBe(true);
@@ -65,9 +84,10 @@ describe('WebhookSignatureService', () => {
   describe('verifySignature', () => {
     it('should verify valid signature', () => {
       const payload = JSON.stringify({ paymentId: '123', status: 'COMPLETED' });
-      const signature = service.generateSignature(payload);
+      const validTimestamp = currentTimestamp();
+      const signature = service.generateSignature(payload, validTimestamp);
 
-      const isValid = service.verifySignature(payload, signature);
+      const isValid = service.verifySignature(payload, signature, validTimestamp);
 
       expect(isValid).toBe(true);
     });
@@ -75,16 +95,22 @@ describe('WebhookSignatureService', () => {
     it('should reject invalid signature', () => {
       const payload = JSON.stringify({ paymentId: '123', status: 'COMPLETED' });
       const invalidSignature = 'invalid_signature_123456';
+      const validTimestamp = currentTimestamp();
 
-      const isValid = service.verifySignature(payload, invalidSignature);
+      const isValid = service.verifySignature(
+        payload,
+        invalidSignature,
+        validTimestamp,
+      );
 
       expect(isValid).toBe(false);
     });
 
     it('should reject missing signature', () => {
       const payload = JSON.stringify({ paymentId: '123', status: 'COMPLETED' });
+      const validTimestamp = currentTimestamp();
 
-      const isValid = service.verifySignature(payload, '');
+      const isValid = service.verifySignature(payload, '', validTimestamp);
 
       expect(isValid).toBe(false);
     });
@@ -98,9 +124,10 @@ describe('WebhookSignatureService', () => {
         paymentId: '123',
         status: 'FAILED',
       });
+      const validTimestamp = currentTimestamp();
 
-      const signature = service.generateSignature(payload1);
-      const isValid = service.verifySignature(payload2, signature);
+      const signature = service.generateSignature(payload1, validTimestamp);
+      const isValid = service.verifySignature(payload2, signature, validTimestamp);
 
       expect(isValid).toBe(false);
     });
@@ -108,11 +135,55 @@ describe('WebhookSignatureService', () => {
     it('should work with Buffer payload', () => {
       const payload = JSON.stringify({ paymentId: '123', status: 'COMPLETED' });
       const buffer = Buffer.from(payload);
-      const signature = service.generateSignature(payload);
+      const validTimestamp = currentTimestamp();
+      const signature = service.generateSignature(payload, validTimestamp);
 
-      const isValid = service.verifySignature(buffer, signature);
+      const isValid = service.verifySignature(buffer, signature, validTimestamp);
 
       expect(isValid).toBe(true);
+    });
+
+    it('should reject stale timestamp outside tolerance', () => {
+      const payload = JSON.stringify({ paymentId: '123', status: 'COMPLETED' });
+      const staleTimestamp = String(Math.floor(Date.now() / 1000) - 10 * 60);
+      const signature = service.generateSignature(payload, staleTimestamp);
+
+      const isValid = service.verifySignature(payload, signature, staleTimestamp);
+
+      expect(isValid).toBe(false);
+    });
+
+    it('should reject invalid timestamp format', () => {
+      const payload = JSON.stringify({ paymentId: '123', status: 'COMPLETED' });
+      const validTimestamp = currentTimestamp();
+      const signature = service.generateSignature(payload, validTimestamp);
+
+      const isValid = service.verifySignature(payload, signature, 'not-a-number');
+
+      expect(isValid).toBe(false);
+    });
+
+    it('should reject replayed nonce within tolerance when nonce cache is enabled', () => {
+      const payload = JSON.stringify({ paymentId: '123', status: 'COMPLETED' });
+      const nonce = 'nonce-123';
+      const validTimestamp = currentTimestamp();
+      const signature = service.generateSignature(payload, validTimestamp);
+
+      const firstAttempt = service.verifySignature(
+        payload,
+        signature,
+        validTimestamp,
+        nonce,
+      );
+      const replayAttempt = service.verifySignature(
+        payload,
+        signature,
+        validTimestamp,
+        nonce,
+      );
+
+      expect(firstAttempt).toBe(true);
+      expect(replayAttempt).toBe(false);
     });
   });
 
@@ -135,9 +206,11 @@ describe('WebhookSignatureService', () => {
       );
 
       const payload = JSON.stringify({ test: 'data' });
+      const validTimestamp = currentTimestamp();
       const result = serviceWithoutSecret.verifySignature(
         payload,
         'some-signature',
+        validTimestamp,
       );
 
       expect(result).toBe(false);
@@ -147,12 +220,21 @@ describe('WebhookSignatureService', () => {
   describe('Timing attack resistance', () => {
     it('should use constant-time comparison', () => {
       const payload = JSON.stringify({ test: 'data' });
-      const validSignature = service.generateSignature(payload);
+      const validTimestamp = currentTimestamp();
+      const validSignature = service.generateSignature(payload, validTimestamp);
       const invalidSignature = '0' + validSignature.substring(1);
 
       // Both should fail but comparison should take similar time
-      const result1 = service.verifySignature(payload, validSignature);
-      const result2 = service.verifySignature(payload, invalidSignature);
+      const result1 = service.verifySignature(
+        payload,
+        validSignature,
+        validTimestamp,
+      );
+      const result2 = service.verifySignature(
+        payload,
+        invalidSignature,
+        validTimestamp,
+      );
 
       expect(result1).toBe(true);
       expect(result2).toBe(false);

--- a/src/modules/payments/webhook-signature.service.ts
+++ b/src/modules/payments/webhook-signature.service.ts
@@ -10,10 +10,27 @@ import * as crypto from 'crypto';
 export class WebhookSignatureService {
   private readonly webhookSecret: string;
   private readonly signatureAlgorithm = 'sha256';
-  private readonly signatureHeader = 'x-signature';
+  private readonly defaultToleranceMinutes = 5;
+  private readonly timestampToleranceMs: number;
+  private readonly nonceReplayCacheEnabled: boolean;
+  private readonly usedNonces = new Map<string, number>();
 
   constructor(private configService: ConfigService) {
     this.webhookSecret = this.configService.get<string>('WEBHOOK_SECRET') || '';
+    const toleranceMinutes = Number(
+      this.configService.get<string | number>(
+        'WEBHOOK_TIMESTAMP_TOLERANCE_MINUTES',
+        this.defaultToleranceMinutes,
+      ),
+    );
+    this.timestampToleranceMs = Math.max(0, toleranceMinutes) * 60 * 1000;
+    this.nonceReplayCacheEnabled =
+      String(
+        this.configService.get<string | boolean>(
+          'WEBHOOK_NONCE_REPLAY_CACHE_ENABLED',
+          'false',
+        ),
+      ).toLowerCase() === 'true';
 
     if (!this.webhookSecret) {
       console.warn(
@@ -26,9 +43,16 @@ export class WebhookSignatureService {
    * Verify webhook signature
    * @param payload - The raw request body
    * @param signature - The signature from the X-Signature header
+   * @param timestamp - The Unix timestamp from X-Signature-Timestamp header (seconds)
+   * @param nonce - Optional nonce from X-Signature-Nonce for replay detection
    * @returns True if signature is valid, false otherwise
    */
-  verifySignature(payload: string | Buffer, signature: string): boolean {
+  verifySignature(
+    payload: string | Buffer,
+    signature: string,
+    timestamp: string,
+    nonce?: string,
+  ): boolean {
     if (!this.webhookSecret) {
       console.warn(
         'WEBHOOK_SECRET not configured. Skipping signature verification.',
@@ -41,12 +65,34 @@ export class WebhookSignatureService {
     }
 
     try {
+      const timestampInSeconds = Number(timestamp);
+      if (!Number.isFinite(timestampInSeconds) || timestampInSeconds <= 0) {
+        return false;
+      }
+
+      const now = Date.now();
+      const timestampMs = timestampInSeconds * 1000;
+      if (Math.abs(now - timestampMs) > this.timestampToleranceMs) {
+        return false;
+      }
+
+      if (this.nonceReplayCacheEnabled && nonce) {
+        this.pruneExpiredNonces(now);
+        if (this.usedNonces.has(nonce)) {
+          return false;
+        }
+      }
+
       const payloadString =
         typeof payload === 'string' ? payload : payload.toString();
-      const expectedSignature = this.generateSignature(payloadString);
+      const expectedSignature = this.generateSignature(payloadString, timestamp);
 
       // Use constant-time comparison to prevent timing attacks
-      return this.constantTimeCompare(signature, expectedSignature);
+      const isValid = this.constantTimeCompare(signature, expectedSignature);
+      if (isValid && this.nonceReplayCacheEnabled && nonce) {
+        this.usedNonces.set(nonce, timestampMs);
+      }
+      return isValid;
     } catch {
       return false;
     }
@@ -55,12 +101,14 @@ export class WebhookSignatureService {
   /**
    * Generate a signature for a payload
    * @param payload - The payload to sign
+   * @param timestamp - Unix timestamp in seconds used in signing string
    * @returns The generated signature
    */
-  generateSignature(payload: string): string {
+  generateSignature(payload: string, timestamp: string): string {
+    const signedPayload = `${timestamp}.${payload}`;
     return crypto
       .createHmac(this.signatureAlgorithm, this.webhookSecret)
-      .update(payload)
+      .update(signedPayload)
       .digest('hex');
   }
 
@@ -80,5 +128,14 @@ export class WebhookSignatureService {
       result |= a.charCodeAt(i) ^ b.charCodeAt(i);
     }
     return result === 0;
+  }
+
+  private pruneExpiredNonces(nowMs: number): void {
+    const expiryThreshold = nowMs - this.timestampToleranceMs;
+    for (const [nonce, nonceTimestampMs] of this.usedNonces.entries()) {
+      if (nonceTimestampMs < expiryThreshold) {
+        this.usedNonces.delete(nonce);
+      }
+    }
   }
 }

--- a/src/modules/payments/webhook.guard.spec.ts
+++ b/src/modules/payments/webhook.guard.spec.ts
@@ -9,6 +9,7 @@ describe('WebhookGuard', () => {
   let signatureService: WebhookSignatureService;
 
   const mockPayload = JSON.stringify({ paymentId: '123', status: 'COMPLETED' });
+  const timestamp = String(Math.floor(Date.now() / 1000));
   let validSignature: string;
 
   beforeEach(async () => {
@@ -54,7 +55,10 @@ describe('WebhookGuard', () => {
 
     it('should throw when signature is invalid', () => {
       const mockRequest = {
-        headers: { 'x-signature': 'invalid_signature' },
+        headers: {
+          'x-signature': 'invalid_signature',
+          'x-signature-timestamp': timestamp,
+        },
         body: mockPayload,
       } as unknown as Request;
 
@@ -74,7 +78,10 @@ describe('WebhookGuard', () => {
 
     it('should allow request with valid signature', () => {
       const mockRequest = {
-        headers: { 'x-signature': validSignature },
+        headers: {
+          'x-signature': validSignature,
+          'x-signature-timestamp': timestamp,
+        },
         body: mockPayload,
       } as unknown as Request;
 
@@ -94,7 +101,10 @@ describe('WebhookGuard', () => {
     it('should pass request body to signature verification', () => {
       const customPayload = JSON.stringify({ custom: 'data' });
       const mockRequest = {
-        headers: { 'x-signature': validSignature },
+        headers: {
+          'x-signature': validSignature,
+          'x-signature-timestamp': timestamp,
+        },
         body: customPayload,
       } as unknown as Request;
 
@@ -111,13 +121,18 @@ describe('WebhookGuard', () => {
       expect(signatureService.verifySignature).toHaveBeenCalledWith(
         customPayload,
         validSignature,
+        timestamp,
+        undefined,
       );
     });
 
     it('should handle string body', () => {
       const stringPayload = '{"test":"data"}';
       const mockRequest = {
-        headers: { 'x-signature': validSignature },
+        headers: {
+          'x-signature': validSignature,
+          'x-signature-timestamp': timestamp,
+        },
         body: stringPayload,
       } as unknown as Request;
 
@@ -134,6 +149,26 @@ describe('WebhookGuard', () => {
       expect(signatureService.verifySignature).toHaveBeenCalledWith(
         stringPayload,
         validSignature,
+        timestamp,
+        undefined,
+      );
+    });
+
+    it('should throw when X-Signature-Timestamp header is missing', () => {
+      const mockRequest = {
+        headers: { 'x-signature': validSignature },
+        body: mockPayload,
+      } as unknown as Request;
+
+      const mockContext = {
+        switchToHttp: () => ({
+          getRequest: () => mockRequest,
+        }),
+      } as unknown as ExecutionContext;
+
+      expect(() => guard.canActivate(mockContext)).toThrow(BadRequestException);
+      expect(() => guard.canActivate(mockContext)).toThrow(
+        'Missing X-Signature-Timestamp header',
       );
     });
   });

--- a/src/modules/payments/webhook.guard.ts
+++ b/src/modules/payments/webhook.guard.ts
@@ -22,17 +22,31 @@ export class WebhookGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest<Request>();
     const signature = request.headers['x-signature'] as string;
+    const timestamp = request.headers['x-signature-timestamp'] as string;
+    const nonce = request.headers['x-signature-nonce'] as string | undefined;
 
     if (!signature) {
       throw new BadRequestException(
         'Missing X-Signature header. Please verify the webhook is correctly configured.',
       );
     }
+    if (!timestamp) {
+      throw new BadRequestException(
+        'Missing X-Signature-Timestamp header. Please verify the webhook is correctly configured.',
+      );
+    }
 
     // Get raw body for signature verification
     const rawBody = this.getRawBody(request);
 
-    if (!this.webhookSignatureService.verifySignature(rawBody, signature)) {
+    if (
+      !this.webhookSignatureService.verifySignature(
+        rawBody,
+        signature,
+        timestamp,
+        nonce,
+      )
+    ) {
       throw new BadRequestException(
         'Invalid webhook signature. Unauthorised webhook source.',
       );

--- a/src/modules/settlements/settlements.module.ts
+++ b/src/modules/settlements/settlements.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
+import { ConfigModule } from '@nestjs/config';
 import { Settlement } from './entities/settlement.entity';
 import { MerchantSettlementConfig } from './entities/merchant-settlement-config.entity';
 import { SettlementsService } from './settlements.service';
@@ -12,6 +13,7 @@ import { MailService } from '../auth/mail/mail.service';
 
 @Module({
   imports: [
+    ConfigModule,
     ScheduleModule.forRoot(),
     TypeOrmModule.forFeature([Settlement, MerchantSettlementConfig, Payment]),
     UsersModule,

--- a/src/modules/settlements/settlements.service.spec.ts
+++ b/src/modules/settlements/settlements.service.spec.ts
@@ -1,0 +1,179 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { Repository } from 'typeorm';
+import { SettlementsService } from './settlements.service';
+import { Settlement } from './entities/settlement.entity';
+import {
+  MerchantSettlementConfig,
+  SettlementSchedule,
+} from './entities/merchant-settlement-config.entity';
+import { Payment, PaymentStatus } from '../payments/payment.entity';
+import { MailService } from '../auth/mail/mail.service';
+import { UsersService } from '../users/users.service';
+
+describe('SettlementsService', () => {
+  let service: SettlementsService;
+  let settlementRepo: Repository<Settlement>;
+  let paymentRepo: Repository<Payment>;
+  let configRepo: Repository<MerchantSettlementConfig>;
+
+  const merchantId = 'merchant-1';
+  const config: MerchantSettlementConfig = {
+    id: 'config-1',
+    userId: merchantId,
+    schedule: SettlementSchedule.DAILY,
+    currency: 'USD',
+    lastSettledAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const completedPayments = [
+    {
+      id: 'payment-1',
+      amount: 100,
+      netAmount: 95,
+      feeAmount: 5,
+      status: PaymentStatus.COMPLETED,
+      currency: 'USD',
+      merchantId,
+      updatedAt: new Date(),
+    },
+    {
+      id: 'payment-2',
+      amount: 50,
+      netAmount: 47.5,
+      feeAmount: 2.5,
+      status: PaymentStatus.COMPLETED,
+      currency: 'USD',
+      merchantId,
+      updatedAt: new Date(),
+    },
+  ] as Payment[];
+
+  const buildModule = async (settlementUseGrossAmount = false) => {
+    const queryBuilder = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue(completedPayments),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SettlementsService,
+        {
+          provide: getRepositoryToken(Settlement),
+          useValue: {
+            create: jest.fn().mockImplementation((payload) => payload),
+            save: jest.fn().mockImplementation(async (payload) => ({
+              ...payload,
+              id: 'settlement-1',
+            })),
+            find: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(MerchantSettlementConfig),
+          useValue: {
+            findOneBy: jest.fn(),
+            find: jest.fn().mockResolvedValue([config]),
+            save: jest.fn().mockResolvedValue(config),
+          },
+        },
+        {
+          provide: getRepositoryToken(Payment),
+          useValue: {
+            createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+            update: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: MailService,
+          useValue: {
+            sendSettlementNotification: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: UsersService,
+          useValue: {
+            findOne: jest.fn().mockResolvedValue({ email: 'merchant@test.com' }),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, defaultValue?: unknown) => {
+              if (key === 'SETTLEMENT_USE_GROSS_AMOUNT') {
+                return settlementUseGrossAmount ? 'true' : 'false';
+              }
+              return defaultValue;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<SettlementsService>(SettlementsService);
+    settlementRepo = module.get<Repository<Settlement>>(
+      getRepositoryToken(Settlement),
+    );
+    configRepo = module.get<Repository<MerchantSettlementConfig>>(
+      getRepositoryToken(MerchantSettlementConfig),
+    );
+    paymentRepo = module.get<Repository<Payment>>(getRepositoryToken(Payment));
+  };
+
+  it('settles with net amounts by default', async () => {
+    await buildModule(false);
+
+    const result = await service.triggerManualRun();
+
+    expect(result.settlementsCreated).toBe(1);
+    expect(result.totalAmount).toBe(142.5);
+    expect(settlementRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        totalAmount: 142.5,
+      }),
+    );
+  });
+
+  it('can settle with gross amounts when configured', async () => {
+    await buildModule(true);
+
+    const result = await service.triggerManualRun();
+
+    expect(result.settlementsCreated).toBe(1);
+    expect(result.totalAmount).toBe(150);
+    expect(settlementRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        totalAmount: 150,
+      }),
+    );
+  });
+
+  it('filters completed payments by merchantId when settling', async () => {
+    await buildModule(false);
+
+    await service.triggerManualRun();
+
+    const createQueryBuilder = paymentRepo.createQueryBuilder as jest.Mock;
+    const queryBuilder = createQueryBuilder.mock.results[0].value;
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'p.merchantId = :merchantId',
+      { merchantId: config.userId },
+    );
+  });
+
+  it('updates config and payment settlement linkage after settlement', async () => {
+    await buildModule(false);
+
+    await service.triggerManualRun();
+
+    expect(configRepo.save).toHaveBeenCalled();
+    expect(paymentRepo.update).toHaveBeenCalledWith(
+      { id: expect.anything() },
+      { settlementId: 'settlement-1' },
+    );
+  });
+});

--- a/src/modules/settlements/settlements.service.ts
+++ b/src/modules/settlements/settlements.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { Cron, CronExpression } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
 import { Settlement } from './entities/settlement.entity';
 import {
   MerchantSettlementConfig,
@@ -14,6 +15,8 @@ import { UsersService } from '../users/users.service';
 
 @Injectable()
 export class SettlementsService {
+  private readonly settleOnGross: boolean;
+
   constructor(
     @InjectRepository(Settlement)
     private readonly settlementRepo: Repository<Settlement>,
@@ -23,7 +26,16 @@ export class SettlementsService {
     private readonly paymentRepo: Repository<Payment>,
     private readonly mailService: MailService,
     private readonly usersService: UsersService,
-  ) {}
+    private readonly configService: ConfigService,
+  ) {
+    this.settleOnGross =
+      String(
+        this.configService.get<string | boolean>(
+          'SETTLEMENT_USE_GROSS_AMOUNT',
+          'false',
+        ),
+      ).toLowerCase() === 'true';
+  }
 
   async upsertConfig(userId: string, dto: UpsertSettlementConfigDto): Promise<MerchantSettlementConfig> {
     let config = await this.configRepo.findOneBy({ userId });
@@ -103,6 +115,7 @@ export class SettlementsService {
     const completedPayments = await this.paymentRepo
       .createQueryBuilder('p')
       .where('p.status = :status', { status: PaymentStatus.COMPLETED })
+      .andWhere('p.merchantId = :merchantId', { merchantId: config.userId })
       .andWhere('p.currency = :currency', { currency: config.currency })
       .andWhere('p.updatedAt > :since', { since })
       .getMany();
@@ -110,7 +123,15 @@ export class SettlementsService {
     if (completedPayments.length === 0) return null;
 
     const totalAmount = completedPayments.reduce(
-      (sum, p) => sum + Number(p.amount),
+      (sum, p) =>
+        sum +
+        Number(
+          this.settleOnGross
+            ? p.amount
+            : p.netAmount !== undefined && p.netAmount !== null
+              ? p.netAmount
+              : p.amount,
+        ),
       0,
     );
 

--- a/test/auth-and-merchant-fees.e2e-spec.ts
+++ b/test/auth-and-merchant-fees.e2e-spec.ts
@@ -1,0 +1,149 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { DataSource, Repository } from 'typeorm';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+import { User } from './../src/modules/users/user.entity';
+import { UserRole } from './../src/common/constants/roles';
+
+describe('Auth unlock + merchant fee self-service (e2e)', () => {
+  let app: INestApplication<App>;
+  let userRepo: Repository<User>;
+  const suffix = Date.now();
+
+  const adminCreds = {
+    email: `admin-${suffix}@example.com`,
+    password: 'AdminPass1!',
+  };
+  const merchantCreds = {
+    email: `merchant-${suffix}@example.com`,
+    password: 'MerchantPass1!',
+  };
+  const otherCreds = {
+    email: `other-${suffix}@example.com`,
+    password: 'OtherPass1!',
+  };
+
+  let adminId: string;
+  let merchantId: string;
+  let otherUserId: string;
+  let adminToken: string;
+  let merchantToken: string;
+
+  const createUser = async (payload: { email: string; password: string }) => {
+    const res = await request(app.getHttpServer())
+      .post('/v1/users')
+      .send(payload)
+      .expect(201);
+    return res.body.id as string;
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    const dataSource = app.get(DataSource);
+    userRepo = dataSource.getRepository(User);
+
+    adminId = await createUser(adminCreds);
+    merchantId = await createUser(merchantCreds);
+    otherUserId = await createUser(otherCreds);
+
+    await userRepo.update(adminId, {
+      isEmailVerified: true,
+      roles: [UserRole.ADMIN],
+    });
+    await userRepo.update(merchantId, {
+      isEmailVerified: true,
+      roles: [UserRole.USER],
+    });
+    await userRepo.update(otherUserId, {
+      isEmailVerified: true,
+      roles: [UserRole.USER],
+      failedLoginAttempts: 5,
+      lockedUntil: new Date(Date.now() + 1000 * 60 * 15),
+    });
+
+    adminToken = (
+      await request(app.getHttpServer())
+        .post('/v1/auth/login')
+        .send(adminCreds)
+        .expect(200)
+    ).body.access_token;
+
+    merchantToken = (
+      await request(app.getHttpServer())
+        .post('/v1/auth/login')
+        .send(merchantCreds)
+        .expect(200)
+    ).body.access_token;
+
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('allows admin token to unlock account', async () => {
+    const response = await request(app.getHttpServer())
+      .post(`/v1/auth/unlock/${otherUserId}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .expect(200);
+
+    expect(response.body.id).toBe(otherUserId);
+    expect(response.body.failedLoginAttempts).toBe(0);
+    expect(response.body.lockedUntil).toBeNull();
+  });
+
+  it('forbids non-admin users from unlocking account', async () => {
+    await request(app.getHttpServer())
+      .post(`/v1/auth/unlock/${otherUserId}`)
+      .set('Authorization', `Bearer ${merchantToken}`)
+      .expect(403);
+  });
+
+  it('lets merchant fetch own fee config and report', async () => {
+    await request(app.getHttpServer())
+      .post(`/v1/payments/merchant-fee-config/${merchantId}`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        merchantId,
+        flatFee: 1.25,
+        percentageFee: 2.5,
+        minFee: 0.5,
+      })
+      .expect(201);
+
+    const feeConfigResponse = await request(app.getHttpServer())
+      .get('/v1/merchants/me/fee-config')
+      .set('Authorization', `Bearer ${merchantToken}`)
+      .expect(200);
+
+    expect(feeConfigResponse.body.merchantId).toBe(merchantId);
+    expect(Number(feeConfigResponse.body.flatFee)).toBe(1.25);
+    expect(Number(feeConfigResponse.body.percentageFee)).toBe(2.5);
+    expect(Number(feeConfigResponse.body.minFee)).toBe(0.5);
+
+    const feeReportResponse = await request(app.getHttpServer())
+      .get('/v1/merchants/me/fee-report')
+      .set('Authorization', `Bearer ${merchantToken}`)
+      .expect(200);
+
+    expect(feeReportResponse.body.merchantId).toBe(merchantId);
+    expect(feeReportResponse.body).toHaveProperty('totalGrossAmount');
+    expect(feeReportResponse.body).toHaveProperty('totalFeeAmount');
+    expect(feeReportResponse.body).toHaveProperty('totalNetAmount');
+  });
+
+  it('prevents merchant from fetching another merchant fee data through admin-only endpoint', async () => {
+    await request(app.getHttpServer())
+      .get(`/v1/payments/merchant-fee-config/${otherUserId}/report`)
+      .set('Authorization', `Bearer ${merchantToken}`)
+      .expect(403);
+  });
+});

--- a/test/payments.e2e-spec.ts
+++ b/test/payments.e2e-spec.ts
@@ -7,10 +7,10 @@ import { AppModule } from './../src/app.module';
 
 const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET || '';
 
-function generateSignature(body: object): string {
+function generateSignature(body: object, timestamp: string): string {
   return crypto
     .createHmac('sha256', WEBHOOK_SECRET)
-    .update(JSON.stringify(body))
+    .update(`${timestamp}.${JSON.stringify(body)}`)
     .digest('hex');
 }
 
@@ -164,7 +164,20 @@ describe('PaymentsModule (e2e)', () => {
     it('returns 400 when X-Signature header is missing', async () => {
       await request(app.getHttpServer())
         .post('/v1/payments/webhook')
+        .set('X-Signature-Timestamp', String(Math.floor(Date.now() / 1000)))
         .send({ paymentId, status: 'COMPLETED' })
+        .expect(400);
+    });
+
+    it('returns 400 when X-Signature-Timestamp header is missing', async () => {
+      const body = { paymentId, status: 'COMPLETED' };
+      const timestamp = String(Math.floor(Date.now() / 1000));
+      const signature = generateSignature(body, timestamp);
+
+      await request(app.getHttpServer())
+        .post('/v1/payments/webhook')
+        .set('X-Signature', signature)
+        .send(body)
         .expect(400);
     });
 
@@ -172,6 +185,7 @@ describe('PaymentsModule (e2e)', () => {
       await request(app.getHttpServer())
         .post('/v1/payments/webhook')
         .set('X-Signature', 'invalid-signature')
+        .set('X-Signature-Timestamp', String(Math.floor(Date.now() / 1000)))
         .send({ paymentId, status: 'COMPLETED' })
         .expect(400);
     });
@@ -182,11 +196,13 @@ describe('PaymentsModule (e2e)', () => {
         status: 'COMPLETED',
         externalReference: 'EXT-E2E-123',
       };
-      const signature = generateSignature(body);
+      const timestamp = String(Math.floor(Date.now() / 1000));
+      const signature = generateSignature(body, timestamp);
 
       const response = await request(app.getHttpServer())
         .post('/v1/payments/webhook')
         .set('X-Signature', signature)
+        .set('X-Signature-Timestamp', timestamp)
         .send(body)
         .expect(200);
 
@@ -201,11 +217,13 @@ describe('PaymentsModule (e2e)', () => {
         .expect(201);
 
       const body = { paymentId: newPayment.body.id, status: 'FAILED' };
-      const signature = generateSignature(body);
+      const timestamp = String(Math.floor(Date.now() / 1000));
+      const signature = generateSignature(body, timestamp);
 
       const response = await request(app.getHttpServer())
         .post('/v1/payments/webhook')
         .set('X-Signature', signature)
+        .set('X-Signature-Timestamp', timestamp)
         .send(body)
         .expect(200);
 
@@ -215,13 +233,28 @@ describe('PaymentsModule (e2e)', () => {
     it('returns 404 via webhook for a non-existent payment ID', async () => {
       const nonExistentId = '00000000-0000-4000-a000-000000000000';
       const body = { paymentId: nonExistentId, status: 'COMPLETED' };
-      const signature = generateSignature(body);
+      const timestamp = String(Math.floor(Date.now() / 1000));
+      const signature = generateSignature(body, timestamp);
 
       await request(app.getHttpServer())
         .post('/v1/payments/webhook')
         .set('X-Signature', signature)
+        .set('X-Signature-Timestamp', timestamp)
         .send(body)
         .expect(404);
+    });
+
+    it('returns 400 when timestamp is outside tolerance window', async () => {
+      const body = { paymentId, status: 'COMPLETED' };
+      const staleTimestamp = String(Math.floor(Date.now() / 1000) - 10 * 60);
+      const signature = generateSignature(body, staleTimestamp);
+
+      await request(app.getHttpServer())
+        .post('/v1/payments/webhook')
+        .set('X-Signature', signature)
+        .set('X-Signature-Timestamp', staleTimestamp)
+        .send(body)
+        .expect(400);
     });
   });
 


### PR DESCRIPTION
 closes #253 Add timestamp-based replay protection to payment webhook signatures
closes #255 Base settlement totals on net (post-fee) payment amounts
closes #258 Fix POST /auth/unlock/:userId being permanently unreachable
closes #260 Add merchant-facing endpoint to view own fee configuration and totals