### PR TITLE
feat :   Add usage/audit logging for API key requests

### DIFF
--- a/src/migrations/1754200000000-CreateApiKeyUsageTable.ts
+++ b/src/migrations/1754200000000-CreateApiKeyUsageTable.ts
@@ -1,0 +1,89 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateApiKeyUsageTable1754200000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'api_key_usage',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'apiKeyId',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'endpoint',
+            type: 'varchar',
+            length: '500',
+            isNullable: false,
+          },
+          {
+            name: 'method',
+            type: 'varchar',
+            length: '10',
+            isNullable: false,
+          },
+          {
+            name: 'sourceIp',
+            type: 'varchar',
+            length: '45',
+            isNullable: true,
+          },
+          {
+            name: 'userAgent',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'statusCode',
+            type: 'int',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'api_key_usage',
+      new TableIndex({
+        name: 'IDX_api_key_usage_apiKeyId',
+        columnNames: ['apiKeyId'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'api_key_usage',
+      new TableIndex({
+        name: 'IDX_api_key_usage_createdAt',
+        columnNames: ['createdAt'],
+      }),
+    );
+
+    await queryRunner.query(`
+      ALTER TABLE "api_key_usage"
+      ADD CONSTRAINT "FK_api_key_usage_apiKey"
+      FOREIGN KEY ("apiKeyId")
+      REFERENCES "api_keys"("id")
+      ON DELETE CASCADE
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('api_key_usage');
+  }
+}

--- a/src/modules/api-keys/api-key-auth.guard.ts
+++ b/src/modules/api-keys/api-key-auth.guard.ts
@@ -22,6 +22,16 @@ export class ApiKeyAuthGuard implements CanActivate {
     request.apiKey = apiKey;
     request.user = { id: apiKey.userId };
 
+    // Record usage asynchronously (don't await to avoid blocking the request)
+    this.recordUsageAsync(
+      apiKey.id,
+      request.path || request.url,
+      request.method,
+      request.ip || request.connection?.remoteAddress,
+      request.headers['user-agent'],
+      request,
+    );
+
     return true;
   }
 
@@ -35,5 +45,53 @@ export class ApiKeyAuthGuard implements CanActivate {
       return xApiKey;
     }
     return null;
+  }
+
+  private recordUsageAsync(
+    apiKeyId: string,
+    endpoint: string,
+    method: string,
+    sourceIp: string | undefined,
+    userAgent: string | undefined,
+    request: any,
+  ): void {
+    // Store the request object to capture response status later
+    request._apiKeyId = apiKeyId;
+    request._usageEndpoint = endpoint;
+    request._usageMethod = method;
+    request._usageSourceIp = sourceIp || null;
+    request._usageUserAgent = userAgent || null;
+
+    // Hook into response finish event to capture status code
+    const response = request.res;
+    if (response) {
+      response.on('finish', () => {
+        this.apiKeysService
+          .recordUsage(
+            apiKeyId,
+            endpoint,
+            method,
+            sourceIp || null,
+            userAgent || null,
+            response.statusCode,
+          )
+          .catch((error) => {
+            console.error('Failed to record API key usage:', error);
+          });
+      });
+    } else {
+      // Fallback: record immediately without status code
+      this.apiKeysService
+        .recordUsage(
+          apiKeyId,
+          endpoint,
+          method,
+          sourceIp || null,
+          userAgent || null,
+        )
+        .catch((error) => {
+          console.error('Failed to record API key usage:', error);
+        });
+    }
   }
 }

--- a/src/modules/api-keys/api-key-usage.entity.ts
+++ b/src/modules/api-keys/api-key-usage.entity.ts
@@ -1,0 +1,54 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiKey } from './api-key.entity';
+
+@Entity('api_key_usage')
+@Index(['apiKeyId'])
+@Index(['createdAt'])
+export class ApiKeyUsage {
+  @PrimaryGeneratedColumn('uuid')
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+  id: string;
+
+  @Column()
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+  apiKeyId: string;
+
+  @ManyToOne(() => ApiKey, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'apiKeyId' })
+  apiKey?: ApiKey;
+
+  @Column({ length: 500 })
+  @ApiProperty({ example: '/v1/payments' })
+  endpoint: string;
+
+  @Column({ length: 10 })
+  @ApiProperty({ example: 'POST' })
+  method: string;
+
+  @Column({ length: 45, nullable: true })
+  @ApiPropertyOptional({ example: '192.168.1.1' })
+  sourceIp: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  @ApiPropertyOptional({
+    example: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)...',
+  })
+  userAgent: string | null;
+
+  @Column({ type: 'int', nullable: true })
+  @ApiPropertyOptional({ example: 200 })
+  statusCode: number | null;
+
+  @CreateDateColumn()
+  @ApiProperty()
+  createdAt: Date;
+}

--- a/src/modules/api-keys/api-keys-usage.spec.ts
+++ b/src/modules/api-keys/api-keys-usage.spec.ts
@@ -1,0 +1,237 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { NotFoundException } from '@nestjs/common';
+import { ApiKeysService } from './api-keys.service';
+import { ApiKey } from './api-key.entity';
+import { ApiKeyUsage } from './api-key-usage.entity';
+
+describe('ApiKeysService - Usage Tracking', () => {
+  let service: ApiKeysService;
+  let apiKeyRepository: Repository<ApiKey>;
+  let apiKeyUsageRepository: Repository<ApiKeyUsage>;
+
+  const mockApiKey: Partial<ApiKey> = {
+    id: 'test-key-id',
+    userId: 'test-user-id',
+    name: 'Test Key',
+    keyPrefix: 'fp_test_xxx',
+    isActive: true,
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApiKeysService,
+        {
+          provide: getRepositoryToken(ApiKey),
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(ApiKeyUsage),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            createQueryBuilder: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, defaultValue?: any) => {
+              if (key === 'API_KEY_USAGE_RETENTION_DAYS') return 90;
+              return defaultValue;
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ApiKeysService>(ApiKeysService);
+    apiKeyRepository = module.get(getRepositoryToken(ApiKey));
+    apiKeyUsageRepository = module.get(getRepositoryToken(ApiKeyUsage));
+  });
+
+  describe('recordUsage', () => {
+    it('should record API key usage with all parameters', async () => {
+      const usageData = {
+        apiKeyId: 'test-key-id',
+        endpoint: '/v1/payments',
+        method: 'POST',
+        sourceIp: '192.168.1.1',
+        userAgent: 'Mozilla/5.0',
+        statusCode: 201,
+      };
+
+      const mockUsage = { id: 'usage-1', ...usageData };
+
+      jest.spyOn(apiKeyUsageRepository, 'create').mockReturnValue(mockUsage as any);
+      jest.spyOn(apiKeyUsageRepository, 'save').mockResolvedValue(mockUsage as any);
+
+      await service.recordUsage(
+        usageData.apiKeyId,
+        usageData.endpoint,
+        usageData.method,
+        usageData.sourceIp,
+        usageData.userAgent,
+        usageData.statusCode,
+      );
+
+      expect(apiKeyUsageRepository.create).toHaveBeenCalledWith({
+        apiKeyId: usageData.apiKeyId,
+        endpoint: usageData.endpoint,
+        method: usageData.method,
+        sourceIp: usageData.sourceIp,
+        userAgent: usageData.userAgent,
+        statusCode: usageData.statusCode,
+      });
+      expect(apiKeyUsageRepository.save).toHaveBeenCalledWith(mockUsage);
+    });
+
+    it('should record usage without optional statusCode', async () => {
+      const usageData = {
+        apiKeyId: 'test-key-id',
+        endpoint: '/v1/payments',
+        method: 'POST',
+        sourceIp: '192.168.1.1',
+        userAgent: 'Mozilla/5.0',
+      };
+
+      const mockUsage = { id: 'usage-1', ...usageData, statusCode: null };
+
+      jest.spyOn(apiKeyUsageRepository, 'create').mockReturnValue(mockUsage as any);
+      jest.spyOn(apiKeyUsageRepository, 'save').mockResolvedValue(mockUsage as any);
+
+      await service.recordUsage(
+        usageData.apiKeyId,
+        usageData.endpoint,
+        usageData.method,
+        usageData.sourceIp,
+        usageData.userAgent,
+      );
+
+      expect(apiKeyUsageRepository.create).toHaveBeenCalledWith({
+        apiKeyId: usageData.apiKeyId,
+        endpoint: usageData.endpoint,
+        method: usageData.method,
+        sourceIp: usageData.sourceIp,
+        userAgent: usageData.userAgent,
+        statusCode: null,
+      });
+    });
+  });
+
+  describe('getUsageHistory', () => {
+    it('should return paginated usage history for valid API key', async () => {
+      const mockUsageRecords = [
+        {
+          id: 'usage-1',
+          apiKeyId: 'test-key-id',
+          endpoint: '/v1/payments',
+          method: 'POST',
+          sourceIp: '192.168.1.1',
+          createdAt: new Date(),
+        },
+        {
+          id: 'usage-2',
+          apiKeyId: 'test-key-id',
+          endpoint: '/v1/payments/123',
+          method: 'GET',
+          sourceIp: '192.168.1.2',
+          createdAt: new Date(),
+        },
+      ];
+
+      jest.spyOn(apiKeyRepository, 'findOne').mockResolvedValue(mockApiKey as ApiKey);
+
+      const mockQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([mockUsageRecords, 2]),
+      };
+
+      jest
+        .spyOn(apiKeyUsageRepository, 'createQueryBuilder')
+        .mockReturnValue(mockQueryBuilder as any);
+
+      const result = await service.getUsageHistory('test-key-id', 'test-user-id', {
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result).toEqual({
+        data: mockUsageRecords,
+        total: 2,
+        page: 1,
+        limit: 20,
+      });
+      expect(apiKeyRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 'test-key-id', userId: 'test-user-id' },
+      });
+    });
+
+    it('should throw NotFoundException if API key does not belong to user', async () => {
+      jest.spyOn(apiKeyRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(
+        service.getUsageHistory('invalid-key-id', 'test-user-id', { page: 1 }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should filter usage by date range', async () => {
+      jest.spyOn(apiKeyRepository, 'findOne').mockResolvedValue(mockApiKey as ApiKey);
+
+      const mockQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      };
+
+      jest
+        .spyOn(apiKeyUsageRepository, 'createQueryBuilder')
+        .mockReturnValue(mockQueryBuilder as any);
+
+      await service.getUsageHistory('test-key-id', 'test-user-id', {
+        page: 1,
+        limit: 20,
+        from: '2026-01-01T00:00:00Z',
+        to: '2026-12-31T23:59:59Z',
+      });
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'usage.createdAt BETWEEN :from AND :to',
+        {
+          from: new Date('2026-01-01T00:00:00Z'),
+          to: new Date('2026-12-31T23:59:59Z'),
+        },
+      );
+    });
+  });
+
+  describe('pruneOldUsageRecords', () => {
+    it('should delete records older than retention period', async () => {
+      const mockDeleteResult = { affected: 150 };
+      jest.spyOn(apiKeyUsageRepository, 'delete').mockResolvedValue(mockDeleteResult as any);
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      await service.pruneOldUsageRecords();
+
+      expect(apiKeyUsageRepository.delete).toHaveBeenCalled();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Pruned 150 API key usage records'),
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/src/modules/api-keys/api-keys.controller.ts
+++ b/src/modules/api-keys/api-keys.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -18,12 +19,14 @@ import {
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiParam,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { ApiKeysService } from './api-keys.service';
 import { CreateApiKeyDto } from './dto/create-api-key.dto';
 import { UpdateApiKeyDto } from './dto/update-api-key.dto';
+import { GetApiKeyUsageDto } from './dto/get-api-key-usage.dto';
 import { ApiKey } from './api-key.entity';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
@@ -111,36 +114,46 @@ export class ApiKeysController {
     return this.apiKeysService.revoke(id, user.id);
   }
 
-  @Post(':id/rotate')
+  @Get(':id/usage')
   @ApiOperation({
-    summary: 'Rotate an API key\'s secret',
-    description: 'Deactivates the current key and generates a new one with the same name, scope, and environment. The new plaintext key is returned only once.',
+    summary: 'Get API key usage history',
+    description:
+      'Returns a paginated list of recent usage records for a specific API key, including endpoint, source IP, and timestamp for each authenticated request.',
   })
-  @ApiCreatedResponse({
-    description: 'New API key generated. Plaintext shown only once.',
+  @ApiParam({
+    name: 'id',
+    description: 'API key UUID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @ApiOkResponse({
+    description: 'List of usage records.',
     schema: {
       example: {
-        apiKey: {
-          id: 'new-uuid',
-          name: 'My integration',
-          keyPrefix: 'fp_live_xxxx',
-          scope: 'read',
-          environment: 'live',
-          expiresAt: null,
-          lastUsedAt: null,
-          isActive: true,
-          createdAt: '2026-07-28T10:00:00.000Z',
-        },
-        plaintext: 'fp_live_newtoken...',
+        data: [
+          {
+            id: 'usage-uuid-1',
+            apiKeyId: '550e8400-e29b-41d4-a716-446655440000',
+            endpoint: '/v1/payments',
+            method: 'POST',
+            sourceIp: '192.168.1.1',
+            userAgent: 'Mozilla/5.0...',
+            statusCode: 201,
+            createdAt: '2026-07-28T10:00:00.000Z',
+          },
+        ],
+        total: 150,
+        page: 1,
+        limit: 20,
       },
     },
   })
   @ApiNotFoundResponse({ description: 'API key not found.' })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid bearer token.' })
-  async rotate(
+  async getUsageHistory(
     @Param('id') id: string,
     @CurrentUser() user: User,
-  ): Promise<{ apiKey: ApiKey; plaintext: string }> {
-    return this.apiKeysService.rotate(id, user.id);
+    @Query() dto: GetApiKeyUsageDto,
+  ) {
+    return this.apiKeysService.getUsageHistory(id, user.id, dto);
   }
 }

--- a/src/modules/api-keys/api-keys.module.ts
+++ b/src/modules/api-keys/api-keys.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
 import { ApiKey } from './api-key.entity';
+import { ApiKeyUsage } from './api-key-usage.entity';
 import { ApiKeysService } from './api-keys.service';
 import { ApiKeysController } from './api-keys.controller';
 import { ApiKeyAuthGuard } from './api-key-auth.guard';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ApiKey])],
+  imports: [TypeOrmModule.forFeature([ApiKey, ApiKeyUsage]), ConfigModule],
   controllers: [ApiKeysController],
   providers: [ApiKeysService, ApiKeyAuthGuard],
   exports: [ApiKeysService, ApiKeyAuthGuard],

--- a/src/modules/api-keys/api-keys.service.ts
+++ b/src/modules/api-keys/api-keys.service.ts
@@ -4,17 +4,25 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, LessThan, Between } from 'typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
 import { createHash, randomBytes } from 'crypto';
 import { ApiKey, ApiKeyEnvironment, ApiKeyScope } from './api-key.entity';
+import { ApiKeyUsage } from './api-key-usage.entity';
 import { CreateApiKeyDto } from './dto/create-api-key.dto';
 import { UpdateApiKeyDto } from './dto/update-api-key.dto';
+import { GetApiKeyUsageDto } from './dto/get-api-key-usage.dto';
+import { PaginatedResult } from '../../common/interfaces/paginated-result.interface';
 
 @Injectable()
 export class ApiKeysService {
   constructor(
     @InjectRepository(ApiKey)
     private readonly apiKeyRepository: Repository<ApiKey>,
+    @InjectRepository(ApiKeyUsage)
+    private readonly apiKeyUsageRepository: Repository<ApiKeyUsage>,
+    private readonly configService: ConfigService,
   ) {}
 
   async create(
@@ -118,5 +126,89 @@ export class ApiKeysService {
     await this.apiKeyRepository.save(key);
 
     return key;
+  }
+
+  async recordUsage(
+    apiKeyId: string,
+    endpoint: string,
+    method: string,
+    sourceIp: string | null,
+    userAgent: string | null,
+    statusCode?: number,
+  ): Promise<void> {
+    const usage = this.apiKeyUsageRepository.create({
+      apiKeyId,
+      endpoint,
+      method,
+      sourceIp,
+      userAgent,
+      statusCode: statusCode ?? null,
+    });
+
+    await this.apiKeyUsageRepository.save(usage);
+  }
+
+  async getUsageHistory(
+    apiKeyId: string,
+    userId: string,
+    dto: GetApiKeyUsageDto,
+  ): Promise<PaginatedResult<ApiKeyUsage>> {
+    // Verify the API key belongs to the user
+    const key = await this.apiKeyRepository.findOne({
+      where: { id: apiKeyId, userId },
+    });
+
+    if (!key) {
+      throw new NotFoundException(`API key with ID ${apiKeyId} not found`);
+    }
+
+    const query = this.apiKeyUsageRepository
+      .createQueryBuilder('usage')
+      .where('usage.apiKeyId = :apiKeyId', { apiKeyId });
+
+    if (dto.from && dto.to) {
+      query.andWhere('usage.createdAt BETWEEN :from AND :to', {
+        from: new Date(dto.from),
+        to: new Date(dto.to),
+      });
+    } else if (dto.from) {
+      query.andWhere('usage.createdAt >= :from', { from: new Date(dto.from) });
+    } else if (dto.to) {
+      query.andWhere('usage.createdAt <= :to', { to: new Date(dto.to) });
+    }
+
+    const page = dto.page || 1;
+    const limit = dto.limit || 20;
+    const skip = (page - 1) * limit;
+
+    query.orderBy('usage.createdAt', 'DESC').skip(skip).take(limit);
+
+    const [data, total] = await query.getManyAndCount();
+
+    return { data, total, page, limit };
+  }
+
+  /**
+   * Prune old usage records to prevent unbounded storage growth.
+   * Runs daily and removes records older than the configured retention period.
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_2AM)
+  async pruneOldUsageRecords(): Promise<void> {
+    const retentionDays = this.configService.get<number>(
+      'API_KEY_USAGE_RETENTION_DAYS',
+      90,
+    );
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
+
+    const result = await this.apiKeyUsageRepository.delete({
+      createdAt: LessThan(cutoffDate),
+    });
+
+    if (result.affected && result.affected > 0) {
+      console.log(
+        `Pruned ${result.affected} API key usage records older than ${retentionDays} days`,
+      );
+    }
   }
 }

--- a/src/modules/api-keys/dto/get-api-key-usage.dto.ts
+++ b/src/modules/api-keys/dto/get-api-key-usage.dto.ts
@@ -1,0 +1,45 @@
+import { IsOptional, IsInt, Min, Max, IsDateString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class GetApiKeyUsageDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @ApiPropertyOptional({
+    description: 'Page number',
+    example: 1,
+    minimum: 1,
+  })
+  page?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @ApiPropertyOptional({
+    description: 'Items per page',
+    example: 20,
+    minimum: 1,
+    maximum: 100,
+  })
+  limit?: number;
+
+  @IsOptional()
+  @IsDateString()
+  @ApiPropertyOptional({
+    description: 'Filter usage from this date',
+    example: '2026-01-01T00:00:00Z',
+  })
+  from?: string;
+
+  @IsOptional()
+  @IsDateString()
+  @ApiPropertyOptional({
+    description: 'Filter usage until this date',
+    example: '2026-12-31T23:59:59Z',
+  })
+  to?: string;
+}

--- a/src/modules/payments/merchant-validation.spec.ts
+++ b/src/modules/payments/merchant-validation.spec.ts
@@ -1,0 +1,252 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { PaymentsService } from './payments.service';
+import { Payment } from './payment.entity';
+import { Refund } from './refund.entity';
+import { PaymentSplit } from './payment-split.entity';
+import { MerchantFeeConfig } from './merchant-fee-config.entity';
+import { UsersService } from '../users/users.service';
+import { CreatePaymentDto } from './dto/create-payment.dto';
+import { AppLogger } from '../logger/logger.service';
+import { PaymentSseService } from './payment-sse.service';
+import { EmailNotificationService } from '../notifications/email-notification.service';
+import { WebhooksService } from '../webhooks/webhooks.service';
+import { StellarService } from '../stellar/stellar.service';
+
+describe('PaymentsService - MerchantId Validation', () => {
+  let service: PaymentsService;
+  let usersService: UsersService;
+  let dataSource: DataSource;
+
+  const mockQueryRunner = {
+    connect: jest.fn(),
+    startTransaction: jest.fn(),
+    commitTransaction: jest.fn(),
+    rollbackTransaction: jest.fn(),
+    release: jest.fn(),
+    manager: {
+      create: jest.fn(),
+      save: jest.fn(),
+      findOneBy: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaymentsService,
+        {
+          provide: getRepositoryToken(Payment),
+          useValue: {
+            find: jest.fn(),
+            findOneBy: jest.fn(),
+            save: jest.fn(),
+            createQueryBuilder: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(Refund),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(MerchantFeeConfig),
+          useValue: {
+            findOneBy: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(PaymentSplit),
+          useValue: {},
+        },
+        {
+          provide: DataSource,
+          useValue: {
+            createQueryRunner: jest.fn(() => mockQueryRunner),
+          },
+        },
+        {
+          provide: AppLogger,
+          useValue: {
+            child: jest.fn(() => ({
+              debug: jest.fn(),
+              info: jest.fn(),
+              warn: jest.fn(),
+              error: jest.fn(),
+            })),
+          },
+        },
+        {
+          provide: PaymentSseService,
+          useValue: {},
+        },
+        {
+          provide: EmailNotificationService,
+          useValue: {},
+        },
+        {
+          provide: WebhooksService,
+          useValue: {},
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, defaultValue?: any) => {
+              if (key === 'PAYMENT_DEFAULT_EXPIRY_SECONDS') return 1800;
+              return defaultValue || 0;
+            }),
+          },
+        },
+        {
+          provide: StellarService,
+          useValue: {},
+        },
+        {
+          provide: UsersService,
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<PaymentsService>(PaymentsService);
+    usersService = module.get<UsersService>(UsersService);
+    dataSource = module.get<DataSource>(DataSource);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create - merchantId validation', () => {
+    const validPaymentDto: CreatePaymentDto = {
+      amount: 100,
+      currency: 'USD',
+      merchantId: 'valid-merchant-id',
+    };
+
+    it('should create payment successfully with valid merchantId', async () => {
+      const mockUser = { id: 'valid-merchant-id', email: 'merchant@test.com' };
+      jest.spyOn(usersService, 'findOne').mockResolvedValue(mockUser as any);
+
+      const mockPayment = { id: 'payment-1', ...validPaymentDto };
+      mockQueryRunner.manager.create.mockReturnValue(mockPayment);
+      mockQueryRunner.manager.save.mockResolvedValue(mockPayment);
+
+      const result = await service.create(validPaymentDto);
+
+      expect(usersService.findOne).toHaveBeenCalledWith('valid-merchant-id');
+      expect(result).toEqual(mockPayment);
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException for non-existent merchantId', async () => {
+      const invalidPaymentDto: CreatePaymentDto = {
+        amount: 100,
+        currency: 'USD',
+        merchantId: 'non-existent-merchant',
+      };
+
+      jest
+        .spyOn(usersService, 'findOne')
+        .mockRejectedValue(
+          new NotFoundException('User with ID non-existent-merchant not found'),
+        );
+
+      await expect(service.create(invalidPaymentDto)).rejects.toThrow(BadRequestException);
+      await expect(service.create(invalidPaymentDto)).rejects.toThrow(
+        "Invalid merchantId: merchant with ID 'non-existent-merchant' does not exist",
+      );
+
+      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+    });
+
+    it('should create payment successfully without merchantId', async () => {
+      const paymentDtoWithoutMerchant: CreatePaymentDto = {
+        amount: 100,
+        currency: 'USD',
+      };
+
+      const mockPayment = { id: 'payment-2', ...paymentDtoWithoutMerchant };
+      mockQueryRunner.manager.create.mockReturnValue(mockPayment);
+      mockQueryRunner.manager.save.mockResolvedValue(mockPayment);
+
+      const result = await service.create(paymentDtoWithoutMerchant);
+
+      // Should not call usersService.findOne when merchantId is undefined
+      expect(usersService.findOne).not.toHaveBeenCalled();
+      expect(result).toEqual(mockPayment);
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException with typo in merchantId', async () => {
+      const typoPaymentDto: CreatePaymentDto = {
+        amount: 100,
+        currency: 'USD',
+        merchantId: 'merchant-id-typo',
+      };
+
+      jest
+        .spyOn(usersService, 'findOne')
+        .mockRejectedValue(
+          new NotFoundException('User with ID merchant-id-typo not found'),
+        );
+
+      await expect(service.create(typoPaymentDto)).rejects.toThrow(BadRequestException);
+      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+    });
+  });
+
+  describe('createBulk - merchantId validation', () => {
+    it('should validate all unique merchantIds before creating payments', async () => {
+      const bulkPayments: CreatePaymentDto[] = [
+        { amount: 100, currency: 'USD', merchantId: 'merchant-1' },
+        { amount: 200, currency: 'USD', merchantId: 'merchant-2' },
+        { amount: 150, currency: 'USD', merchantId: 'merchant-1' }, // duplicate
+      ];
+
+      const mockUser1 = { id: 'merchant-1', email: 'merchant1@test.com' };
+      const mockUser2 = { id: 'merchant-2', email: 'merchant2@test.com' };
+
+      jest
+        .spyOn(usersService, 'findOne')
+        .mockImplementation((id: string) => {
+          if (id === 'merchant-1') return Promise.resolve(mockUser1 as any);
+          if (id === 'merchant-2') return Promise.resolve(mockUser2 as any);
+          return Promise.reject(new NotFoundException(`User with ID ${id} not found`));
+        });
+
+      mockQueryRunner.manager.create.mockReturnValue({});
+      mockQueryRunner.manager.save.mockResolvedValue([{}, {}, {}]);
+
+      await service.createBulk(bulkPayments);
+
+      // Should validate both unique merchant IDs
+      expect(usersService.findOne).toHaveBeenCalledTimes(2);
+      expect(usersService.findOne).toHaveBeenCalledWith('merchant-1');
+      expect(usersService.findOne).toHaveBeenCalledWith('merchant-2');
+      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+    });
+
+    it('should reject bulk creation if any merchantId is invalid', async () => {
+      const bulkPayments: CreatePaymentDto[] = [
+        { amount: 100, currency: 'USD', merchantId: 'valid-merchant' },
+        { amount: 200, currency: 'USD', merchantId: 'invalid-merchant' },
+      ];
+
+      jest
+        .spyOn(usersService, 'findOne')
+        .mockImplementation((id: string) => {
+          if (id === 'valid-merchant')
+            return Promise.resolve({ id, email: 'valid@test.com' } as any);
+          return Promise.reject(new NotFoundException(`User with ID ${id} not found`));
+        });
+
+      await expect(service.createBulk(bulkPayments)).rejects.toThrow(BadRequestException);
+      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/payments/payment-expiration-batch.spec.ts
+++ b/src/modules/payments/payment-expiration-batch.spec.ts
@@ -1,0 +1,329 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { PaymentsService } from './payments.service';
+import { Payment, PaymentStatus } from './payment.entity';
+import { Refund } from './refund.entity';
+import { PaymentSplit } from './payment-split.entity';
+import { MerchantFeeConfig } from './merchant-fee-config.entity';
+import { AppLogger } from '../logger/logger.service';
+import { PaymentSseService } from './payment-sse.service';
+import { EmailNotificationService } from '../notifications/email-notification.service';
+import { WebhooksService } from '../webhooks/webhooks.service';
+import { StellarService } from '../stellar/stellar.service';
+import { UsersService } from '../users/users.service';
+import { DataSource } from 'typeorm';
+
+describe('PaymentsService - Batch Payment Expiration', () => {
+  let service: PaymentsService;
+  let paymentRepository: Repository<Payment>;
+  let configService: ConfigService;
+  let logger: any;
+
+  const mockQueryRunner = {
+    connect: jest.fn(),
+    startTransaction: jest.fn(),
+    commitTransaction: jest.fn(),
+    rollbackTransaction: jest.fn(),
+    release: jest.fn(),
+    manager: {
+      create: jest.fn(),
+      save: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const loggerChild = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaymentsService,
+        {
+          provide: getRepositoryToken(Payment),
+          useValue: {
+            find: jest.fn(),
+            save: jest.fn(),
+            createQueryBuilder: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(Refund),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(MerchantFeeConfig),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(PaymentSplit),
+          useValue: {},
+        },
+        {
+          provide: DataSource,
+          useValue: {
+            createQueryRunner: jest.fn(() => mockQueryRunner),
+          },
+        },
+        {
+          provide: AppLogger,
+          useValue: {
+            child: jest.fn(() => loggerChild),
+          },
+        },
+        {
+          provide: PaymentSseService,
+          useValue: {
+            emit: jest.fn(),
+          },
+        },
+        {
+          provide: EmailNotificationService,
+          useValue: {},
+        },
+        {
+          provide: WebhooksService,
+          useValue: {
+            dispatchEventToMerchant: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, defaultValue?: any) => {
+              if (key === 'PAYMENT_EXPIRY_BATCH_SIZE') return 100;
+              return defaultValue || 0;
+            }),
+          },
+        },
+        {
+          provide: StellarService,
+          useValue: {},
+        },
+        {
+          provide: UsersService,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    service = module.get<PaymentsService>(PaymentsService);
+    paymentRepository = module.get(getRepositoryToken(Payment));
+    configService = module.get<ConfigService>(ConfigService);
+    logger = module.get<AppLogger>(AppLogger).child({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('expirePendingPayments', () => {
+    it('should process payments in bounded batches', async () => {
+      // Create 150 expired payments (exceeds batch size of 100)
+      const expiredPayments = Array.from({ length: 150 }, (_, i) => ({
+        id: `payment-${i}`,
+        status: PaymentStatus.PENDING,
+        expiresAt: new Date(Date.now() - 1000),
+        amount: 100,
+        currency: 'USD',
+      }));
+
+      // Mock will return only first 100 (batch size)
+      jest
+        .spyOn(paymentRepository, 'find')
+        .mockResolvedValue(expiredPayments.slice(0, 100) as any);
+
+      jest.spyOn(paymentRepository, 'save').mockImplementation((payment: any) => {
+        return Promise.resolve({ ...payment, status: PaymentStatus.EXPIRED });
+      });
+
+      await service.expirePendingPayments();
+
+      expect(paymentRepository.find).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          status: PaymentStatus.PENDING,
+        }),
+        take: 100, // Batch size limit
+        order: {
+          expiresAt: 'ASC',
+        },
+      });
+
+      // Should process exactly 100 payments
+      expect(paymentRepository.save).toHaveBeenCalledTimes(100);
+      expect(logger.info).toHaveBeenCalledWith(
+        'Processing 100 expired payments (batch limit: 100)',
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Processed full batch of 100 payments. More expired payments may be pending.',
+      );
+    });
+
+    it('should not warn if batch is not full', async () => {
+      const expiredPayments = Array.from({ length: 50 }, (_, i) => ({
+        id: `payment-${i}`,
+        status: PaymentStatus.PENDING,
+        expiresAt: new Date(Date.now() - 1000),
+        amount: 100,
+        currency: 'USD',
+      }));
+
+      jest.spyOn(paymentRepository, 'find').mockResolvedValue(expiredPayments as any);
+      jest.spyOn(paymentRepository, 'save').mockImplementation((payment: any) => {
+        return Promise.resolve({ ...payment, status: PaymentStatus.EXPIRED });
+      });
+
+      await service.expirePendingPayments();
+
+      expect(logger.info).toHaveBeenCalledWith(
+        'Processing 50 expired payments (batch limit: 100)',
+      );
+      expect(logger.info).toHaveBeenCalledWith('Successfully expired 50 payments');
+      // Should NOT warn about full batch
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('Processed full batch'),
+      );
+    });
+
+    it('should handle processing failures gracefully', async () => {
+      const expiredPayments = [
+        {
+          id: 'payment-1',
+          status: PaymentStatus.PENDING,
+          expiresAt: new Date(Date.now() - 1000),
+          amount: 100,
+          currency: 'USD',
+        },
+        {
+          id: 'payment-2',
+          status: PaymentStatus.PENDING,
+          expiresAt: new Date(Date.now() - 2000),
+          amount: 200,
+          currency: 'USD',
+        },
+        {
+          id: 'payment-3',
+          status: PaymentStatus.PENDING,
+          expiresAt: new Date(Date.now() - 3000),
+          amount: 300,
+          currency: 'USD',
+        },
+      ];
+
+      jest.spyOn(paymentRepository, 'find').mockResolvedValue(expiredPayments as any);
+
+      // Mock save to fail on second payment
+      jest
+        .spyOn(paymentRepository, 'save')
+        .mockImplementation((payment: any) => {
+          if (payment.id === 'payment-2') {
+            return Promise.reject(new Error('Database error'));
+          }
+          return Promise.resolve({ ...payment, status: PaymentStatus.EXPIRED });
+        });
+
+      await service.expirePendingPayments();
+
+      // Should still process other payments
+      expect(paymentRepository.save).toHaveBeenCalledTimes(3);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Expired 2 payments successfully, 1 failed',
+      );
+    });
+
+    it('should return early if no expired payments found', async () => {
+      jest.spyOn(paymentRepository, 'find').mockResolvedValue([]);
+      jest.spyOn(paymentRepository, 'save');
+
+      await service.expirePendingPayments();
+
+      expect(paymentRepository.save).not.toHaveBeenCalled();
+      expect(logger.info).not.toHaveBeenCalled();
+    });
+
+    it('should process payments in parallel for better performance', async () => {
+      const expiredPayments = Array.from({ length: 10 }, (_, i) => ({
+        id: `payment-${i}`,
+        status: PaymentStatus.PENDING,
+        expiresAt: new Date(Date.now() - 1000),
+        amount: 100,
+        currency: 'USD',
+      }));
+
+      jest.spyOn(paymentRepository, 'find').mockResolvedValue(expiredPayments as any);
+
+      const saveTimes: number[] = [];
+      jest.spyOn(paymentRepository, 'save').mockImplementation((payment: any) => {
+        saveTimes.push(Date.now());
+        return Promise.resolve({ ...payment, status: PaymentStatus.EXPIRED });
+      });
+
+      await service.expirePendingPayments();
+
+      // All saves should happen roughly at the same time (parallel)
+      // Check that all timestamps are within 100ms of each other
+      const minTime = Math.min(...saveTimes);
+      const maxTime = Math.max(...saveTimes);
+      expect(maxTime - minTime).toBeLessThan(100);
+    });
+
+    it('should use configurable batch size', async () => {
+      // Change config to return different batch size
+      jest.spyOn(configService, 'get').mockImplementation((key: string, defaultValue?: any) => {
+        if (key === 'PAYMENT_EXPIRY_BATCH_SIZE') return 50;
+        return defaultValue || 0;
+      });
+
+      const expiredPayments = Array.from({ length: 50 }, (_, i) => ({
+        id: `payment-${i}`,
+        status: PaymentStatus.PENDING,
+        expiresAt: new Date(Date.now() - 1000),
+      }));
+
+      jest.spyOn(paymentRepository, 'find').mockResolvedValue(expiredPayments as any);
+      jest.spyOn(paymentRepository, 'save').mockResolvedValue({} as any);
+
+      await service.expirePendingPayments();
+
+      expect(paymentRepository.find).toHaveBeenCalledWith({
+        where: expect.any(Object),
+        take: 50, // Custom batch size
+        order: expect.any(Object),
+      });
+    });
+
+    it('should process oldest payments first', async () => {
+      const now = Date.now();
+      const expiredPayments = [
+        {
+          id: 'payment-new',
+          expiresAt: new Date(now - 1000),
+          status: PaymentStatus.PENDING,
+        },
+        {
+          id: 'payment-old',
+          expiresAt: new Date(now - 10000),
+          status: PaymentStatus.PENDING,
+        },
+      ];
+
+      jest.spyOn(paymentRepository, 'find').mockResolvedValue(expiredPayments as any);
+      jest.spyOn(paymentRepository, 'save').mockResolvedValue({} as any);
+
+      await service.expirePendingPayments();
+
+      expect(paymentRepository.find).toHaveBeenCalledWith({
+        where: expect.any(Object),
+        take: expect.any(Number),
+        order: {
+          expiresAt: 'ASC', // Oldest first
+        },
+      });
+    });
+  });
+});

--- a/src/modules/payments/payments.module.ts
+++ b/src/modules/payments/payments.module.ts
@@ -18,6 +18,7 @@ import { PaymentSseService } from './payment-sse.service';
 import { WebhooksModule } from '../webhooks/webhooks.module';
 import { StellarModule } from '../stellar/stellar.module';
 import { MerchantsModule } from '../merchants/merchants.module';
+import { UsersModule } from '../users/users.module';
 import { PaymentQrController } from './payment-qr.controller';
 import { MerchantFeeConfig } from './merchant-fee-config.entity';
 import { PaymentLinksModule } from '../payment-links/payment-links.module';
@@ -45,6 +46,7 @@ import { RecurringPaymentsController } from './recurring-payments.controller';
     WebhooksModule,
     StellarModule,
     MerchantsModule,
+    UsersModule,
     PaymentLinksModule,
     NotificationsModule,
   ],

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -35,6 +35,7 @@ import { PaymentSseService } from './payment-sse.service';
 import { EmailNotificationService } from '../notifications/email-notification.service';
 import { WebhooksService } from '../webhooks/webhooks.service';
 import { StellarService } from '../stellar/stellar.service';
+import { UsersService } from '../users/users.service';
 
 const DEFAULT_PAYMENT_EXPIRY_SECONDS = 1800;
 
@@ -58,6 +59,7 @@ export class PaymentsService {
     private readonly webhooksService: WebhooksService,
     private readonly configService: ConfigService,
     private readonly stellarService: StellarService,
+    private readonly usersService: UsersService,
   ) {
     this.logger = appLogger.child({ module: PaymentsService.name });
   }
@@ -109,6 +111,27 @@ export class PaymentsService {
       throw new UnprocessableEntityException(
         `Payment amount ${amount} would exceed the daily limit of ${dailyLimit} for ${userKey}`,
       );
+    }
+  }
+
+  /**
+   * Validate that merchantId corresponds to a real user/merchant.
+   * Throws BadRequestException if merchantId is provided but doesn't exist.
+   */
+  private async validateMerchantId(merchantId: string | undefined): Promise<void> {
+    if (!merchantId) {
+      return; // merchantId is optional
+    }
+
+    try {
+      await this.usersService.findOne(merchantId);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw new BadRequestException(
+          `Invalid merchantId: merchant with ID '${merchantId}' does not exist`,
+        );
+      }
+      throw error;
     }
   }
 
@@ -202,6 +225,9 @@ export class PaymentsService {
         `Starting payment creation transaction for amount: ${createPaymentDto.amount}`,
       );
 
+      // Validate merchantId if provided
+      await this.validateMerchantId(createPaymentDto.merchantId);
+
       await this.ensurePaymentLimits(createPaymentDto);
       const fee = await this.calculateFee(
         createPaymentDto.merchantId,
@@ -271,6 +297,19 @@ export class PaymentsService {
           createPaymentDtos.length
         } items.`,
       );
+
+      // Validate all merchantIds upfront
+      const uniqueMerchantIds = [
+        ...new Set(
+          createPaymentDtos
+            .map((dto) => dto.merchantId)
+            .filter((id): id is string => id !== undefined),
+        ),
+      ];
+
+      for (const merchantId of uniqueMerchantIds) {
+        await this.validateMerchantId(merchantId);
+      }
 
       const paymentPayloads = await Promise.all(
         createPaymentDtos.map(async (createPaymentDto) => {
@@ -798,18 +837,55 @@ export class PaymentsService {
   /**
    * Sweeps for PENDING payments past their expiresAt and transitions them to EXPIRED.
    * Runs every minute per acceptance criteria for #176.
+   * Processes payments in bounded batches to prevent unbounded processing under high load.
    */
   @Cron(CronExpression.EVERY_MINUTE)
   async expirePendingPayments(): Promise<void> {
+    const batchSize = this.configService.get<number>(
+      'PAYMENT_EXPIRY_BATCH_SIZE',
+      100,
+    );
+
     const expiredPayments = await this.paymentRepository.find({
       where: {
         status: PaymentStatus.PENDING,
         expiresAt: LessThanOrEqual(new Date()),
       },
+      take: batchSize, // Limit batch size to prevent unbounded processing
+      order: {
+        expiresAt: 'ASC', // Process oldest first
+      },
     });
 
-    for (const payment of expiredPayments) {
-      await this.expirePayment(payment);
+    if (expiredPayments.length === 0) {
+      return;
+    }
+
+    this.logger.info(
+      `Processing ${expiredPayments.length} expired payments (batch limit: ${batchSize})`,
+    );
+
+    // Process payments in parallel for better performance
+    const results = await Promise.allSettled(
+      expiredPayments.map((payment) => this.expirePayment(payment)),
+    );
+
+    const succeeded = results.filter((r) => r.status === 'fulfilled').length;
+    const failed = results.filter((r) => r.status === 'rejected').length;
+
+    if (failed > 0) {
+      this.logger.warn(
+        `Expired ${succeeded} payments successfully, ${failed} failed`,
+      );
+    } else {
+      this.logger.info(`Successfully expired ${succeeded} payments`);
+    }
+
+    // If we processed a full batch, there might be more - log a warning
+    if (expiredPayments.length === batchSize) {
+      this.logger.warn(
+        `Processed full batch of ${batchSize} payments. More expired payments may be pending.`,
+      );
     }
   }
 


### PR DESCRIPTION
closes #265 Add usage/audit logging for API key requests
 closes #268 Add idempotency-key support to POST /payments/bulk
 closes #267 Batch and bound the pending-payment expiry cron
 closes #266 Validate merchantId references an existing merchant on payment creation