### PR TITLE
feat: add POST /api-keys/:id/rotate and GET /payments/:id/timeline en…

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,20 +1,31 @@
-# TODO - Multi-currency support (ISO 4217 + supported allowlist)
+# Task: Add API Key Rotation & Payment Timeline Endpoints
 
-- [x] Step 1: Add currency config service reading `SUPPORTED_CURRENCIES` (comma-separated ISO codes)
+## Steps
 
-- [x] Step 2: Add `IsISO4217CurrencyCode` custom validator that validates:
+- [x] Step 1: Add `POST /api-keys/:id/rotate` endpoint in `api-keys.controller.ts`
+- [x] Step 2: Create `payment-timeline.dto.ts` for timeline event types
+- [x] Step 3: Add `getTimeline()` method in `payments.service.ts`
+- [x] Step 4: Add `GET /payments/:id/timeline` endpoint in `payments.controller.ts`
 
-  - ISO 4217 code format (and correctness via internal allowlist)
-  - optional allowlist constraint based on env (`SUPPORTED_CURRENCIES`)
-- [x] Step 3: Update `CreatePaymentDto` to use the new validator for `currency`
+## Summary
 
-- [x] Step 4: Ensure unsupported/invalid currencies return HTTP **422** with descriptive error message
+### 1. POST /v1/api-keys/:id/rotate
+- **File**: `src/modules/api-keys/api-keys.controller.ts`
+- **Description**: Revokes the current API key and creates a new one with the same name, scope, and environment settings. Returns `{ apiKey, plaintext }`.
+- **Auth**: Requires JWT bearer token (uses `@CurrentUser()` decorator)
+- **Service method**: `ApiKeysService.rotate(id, userId)` — already existed, now wired to the endpoint
 
-- [x] Step 5: Add `GET /v1/currencies` endpoint that returns the supported currency list from env
-- [x] Step 6: Update Swagger decorators/examples for the new endpoint and DTO
-- [x] Step 7: Update/extend e2e tests (`test/payments.e2e-spec.ts`) for:
-  - invalid ISO currency -> 422
-  - valid but unsupported currency -> 422
-  - GET /v1/currencies -> returns current env list
-- [ ] Step 8: Run e2e tests locally and fix any regressions
+### 2. GET /v1/payments/:id/timeline
+- **Files**: 
+  - `src/modules/payments/dto/payment-timeline.dto.ts` (new)
+  - `src/modules/payments/payments.service.ts` (new `getTimeline()` method)
+  - `src/modules/payments/payments.controller.ts` (new `@Get(':id/timeline')` endpoint)
+- **Description**: Returns a chronological array of events for a payment, including:
+  - `payment.created` — payment creation
+  - `payment.status_updated` — status transitions
+  - `payment.cancelled` — cancellation
+  - `payment.expired` — expiry
+  - `refund.created` — each refund issued
+  - `dispute.opened` / `dispute.resolved` / `dispute.closed` — dispute lifecycle
+- **Auth**: Requires JWT bearer token
 

--- a/src/modules/api-keys/api-keys.controller.ts
+++ b/src/modules/api-keys/api-keys.controller.ts
@@ -114,6 +114,40 @@ export class ApiKeysController {
     return this.apiKeysService.revoke(id, user.id);
   }
 
+  @Post(':id/rotate')
+  @ApiOperation({
+    summary: 'Rotate an API key',
+    description:
+      'Revokes the current API key and creates a new one with the same name, scope, and environment settings. The new plaintext key is returned only once — store it securely.',
+  })
+  @ApiOkResponse({
+    description: 'API key rotated. New plaintext key shown only once.',
+    schema: {
+      example: {
+        apiKey: {
+          id: '660e8400-e29b-41d4-a716-446655440001',
+          name: 'My integration',
+          keyPrefix: 'fp_live_yyyy',
+          scope: 'read',
+          environment: 'live',
+          expiresAt: null,
+          lastUsedAt: null,
+          isActive: true,
+          createdAt: '2026-06-28T11:00:00.000Z',
+        },
+        plaintext: 'fp_live_xyz789...',
+      },
+    },
+  })
+  @ApiNotFoundResponse({ description: 'API key not found.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid bearer token.' })
+  async rotate(
+    @Param('id') id: string,
+    @CurrentUser() user: User,
+  ): Promise<{ apiKey: ApiKey; plaintext: string }> {
+    return this.apiKeysService.rotate(id, user.id);
+  }
+
   @Get(':id/usage')
   @ApiOperation({
     summary: 'Get API key usage history',

--- a/src/modules/payments/dto/payment-timeline.dto.ts
+++ b/src/modules/payments/dto/payment-timeline.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Represents a single event in a payment's timeline.
+ * Events are aggregated from various sources (payment lifecycle, refunds, disputes, etc.)
+ * and returned in chronological order.
+ */
+export class PaymentTimelineEvent {
+  @ApiProperty({
+    description: 'Event type identifier',
+    example: 'payment.created',
+    enum: [
+      'payment.created',
+      'payment.status_updated',
+      'payment.cancelled',
+      'payment.expired',
+      'refund.created',
+      'dispute.opened',
+      'dispute.updated',
+      'dispute.resolved',
+      'dispute.closed',
+    ],
+  })
+  type!: string;
+
+  @ApiProperty({
+    description: 'Timestamp of the event',
+    example: '2026-01-26T10:00:00.000Z',
+  })
+  timestamp!: Date;
+
+  @ApiPropertyOptional({
+    description: 'Additional event-specific data',
+    example: { amount: 100.5, currency: 'USD', status: 'PENDING' },
+  })
+  data?: Record<string, unknown>;
+}
+

--- a/src/modules/payments/payments.controller.ts
+++ b/src/modules/payments/payments.controller.ts
@@ -54,6 +54,7 @@ import { BulkCreatePaymentsResponseDto } from './dto/bulk-create-payments-respon
 import { RefundPaymentDto } from './dto/refund-payment.dto';
 import { PaymentWebhookDto } from './dto/payment-webhook.dto';
 import { GetPaymentsDto, PaymentSortBy } from './dto/get-payments.dto';
+import { PaymentTimelineEvent } from './dto/payment-timeline.dto';
 import { Payment } from './payment.entity';
 import { Refund } from './refund.entity';
 import { SortOrder } from '../../common/dto/pagination.dto';
@@ -689,6 +690,42 @@ export class PaymentsController {
   })
   cancel(@Param('id') id: string) {
     return this.paymentsService.cancel(id);
+  }
+
+  @Get(':id/timeline')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('bearer')
+  @ApiOperation({
+    summary: 'Get payment timeline',
+    description:
+      'Returns a chronological timeline of events for a payment, including creation, status updates, cancellation, expiry, refunds, and dispute lifecycle events.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Payment UUID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @ApiOkResponse({
+    description: 'Payment timeline events.',
+    schema: {
+      example: [
+        {
+          type: 'payment.created',
+          timestamp: '2026-01-26T10:00:00.000Z',
+          data: { amount: 100.5, currency: 'USD', status: 'PENDING', description: 'Payment for order #12345' },
+        },
+        {
+          type: 'payment.status_updated',
+          timestamp: '2026-01-26T10:05:00.000Z',
+          data: { status: 'COMPLETED' },
+        },
+      ],
+    },
+  })
+  @ApiNotFoundResponse({ description: 'Payment not found.' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid bearer token.' })
+  async getTimeline(@Param('id') id: string): Promise<PaymentTimelineEvent[]> {
+    return this.paymentsService.getTimeline(id);
   }
 
   @Sse(':id/events')

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -16,6 +16,7 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
 import { Payment, PaymentStatus } from './payment.entity';
 import { Refund } from './refund.entity';
+import { Dispute, DisputeStatus } from './dispute.entity';
 import { PaymentSplit, PaymentSplitStatus } from './payment-split.entity';
 import { MerchantFeeConfig } from './merchant-fee-config.entity';
 import { UpsertMerchantFeeConfigDto } from './dto/upsert-merchant-fee-config.dto';
@@ -24,6 +25,7 @@ import { CreatePaymentDto } from './dto/create-payment.dto';
 import { RefundPaymentDto } from './dto/refund-payment.dto';
 import { PaymentWebhookDto } from './dto/payment-webhook.dto';
 import { GetPaymentsDto, PaymentSortBy } from './dto/get-payments.dto';
+import { PaymentTimelineEvent } from './dto/payment-timeline.dto';
 import { SortOrder } from '../../common/dto/pagination.dto';
 import {
   CursorPaginatedResult,
@@ -52,6 +54,8 @@ export class PaymentsService {
     private readonly merchantFeeConfigRepository: Repository<MerchantFeeConfig>,
     @InjectRepository(PaymentSplit)
     private readonly paymentSplitRepository: Repository<PaymentSplit>,
+    @InjectRepository(Dispute)
+    private readonly disputeRepository: Repository<Dispute>,
     private readonly dataSource: DataSource,
     appLogger: AppLogger,
     private readonly paymentSseService: PaymentSseService,
@@ -635,6 +639,119 @@ export class PaymentsService {
       where: { paymentId },
       order: { createdAt: 'DESC' },
     });
+  }
+
+  /**
+   * Returns a chronological timeline of events for a given payment.
+   * Aggregates data from the payment itself, its refunds, and disputes,
+   * sorted by timestamp ascending.
+   */
+  async getTimeline(paymentId: string): Promise<PaymentTimelineEvent[]> {
+    const payment = await this.findOne(paymentId);
+    const events: PaymentTimelineEvent[] = [];
+
+    // Payment creation event
+    events.push({
+      type: 'payment.created',
+      timestamp: payment.createdAt,
+      data: {
+        amount: payment.amount,
+        currency: payment.currency,
+        status: PaymentStatus.PENDING,
+        description: payment.description,
+      },
+    });
+
+    // Status changes reflect via updatedAt
+    if (payment.updatedAt && payment.updatedAt > payment.createdAt) {
+      events.push({
+        type: 'payment.status_updated',
+        timestamp: payment.updatedAt,
+        data: { status: payment.status },
+      });
+    }
+
+    // Cancellation event
+    if (payment.cancelledAt) {
+      events.push({
+        type: 'payment.cancelled',
+        timestamp: payment.cancelledAt,
+        data: { cancelledAt: payment.cancelledAt },
+      });
+    }
+
+    // Expiry event
+    if (payment.expiredAt) {
+      events.push({
+        type: 'payment.expired',
+        timestamp: payment.expiredAt,
+        data: { expiredAt: payment.expiredAt },
+      });
+    }
+
+    // Refund events
+    const refunds = await this.refundRepository.find({
+      where: { paymentId },
+      order: { createdAt: 'ASC' },
+    });
+    for (const refund of refunds) {
+      events.push({
+        type: 'refund.created',
+        timestamp: refund.createdAt,
+        data: {
+          refundId: refund.id,
+          amount: refund.amount,
+          reason: refund.reason,
+          initiatedBy: refund.initiatedBy,
+        },
+      });
+    }
+
+    // Dispute events
+    const disputes = await this.disputeRepository.find({
+      where: { paymentId },
+      order: { createdAt: 'ASC' },
+    });
+    for (const dispute of disputes) {
+      events.push({
+        type: 'dispute.opened',
+        timestamp: dispute.createdAt,
+        data: {
+          disputeId: dispute.id,
+          reason: dispute.reason,
+          description: dispute.description,
+          disputedAmount: dispute.disputedAmount,
+          status: dispute.status,
+        },
+      });
+
+      if (dispute.resolvedAt) {
+        events.push({
+          type: 'dispute.resolved',
+          timestamp: dispute.resolvedAt,
+          data: {
+            disputeId: dispute.id,
+            resolutionNotes: dispute.resolutionNotes,
+            resolvedBy: dispute.resolvedBy,
+          },
+        });
+      }
+
+      if (dispute.closedAt) {
+        events.push({
+          type: 'dispute.closed',
+          timestamp: dispute.closedAt,
+          data: {
+            disputeId: dispute.id,
+          },
+        });
+      }
+    }
+
+    // Sort all events chronologically
+    events.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+    return events;
   }
 
   async refund(


### PR DESCRIPTION
…dpoints
Close issue #210 
#218 
#226 
#259
- Add POST /v1/api-keys/:id/rotate endpoint to rotate API key secrets (revokes old key, creates new one with same settings, returns new plaintext)
- Add GET /v1/payments/:id/timeline endpoint returning chronological payment lifecycle events (creation, status updates, cancellation, expiry, refunds, and dispute lifecycle)
- Create PaymentTimelineEvent DTO with type, timestamp, and data fields
- Add getTimeline() method to PaymentsService that aggregates events from payment, refund, and dispute entities
- Inject DisputeRepository into PaymentsService for dispute event queries